### PR TITLE
Resolved Content-Length issue when posting to API endpoint with empty…

### DIFF
--- a/src/AvaTaxClient.cs
+++ b/src/AvaTaxClient.cs
@@ -567,6 +567,7 @@ namespace Avalara.AvaTax.RestClient
 
             // Convert the name-value pairs into a byte array
             wr.Method = verb;
+            wr.ContentLength = 0;
             if (content != null) {
                 wr.ContentType = Constants.JSON_MIME_TYPE;
                 wr.ServicePoint.Expect100Continue = false;


### PR DESCRIPTION
I have found that several endpoints of the Rest API return LengthRequired along with the following HTTP

`<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
<HTML><HEAD><TITLE>Length Required</TITLE>
<META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
<BODY><h2>Length Required</h2>
<hr><p>HTTP Error 411. The request must be chunked or have a content length.</p>
</BODY></HTML>
`
This seems to be caused by sending a post request with no Content Length header. This appears to happen when the SDK calls a post request and no content is defined. The solution I came up with was to set a manual default value of zero on the ContentLength property (instead of relying on the compiler default).

This change should also resolve an open support case that I have. The case number is 15879211.
