### PR TITLE
Add repository url to nuspec

### DIFF
--- a/src/Avalara.AvaTax.nuspec
+++ b/src/Avalara.AvaTax.nuspec
@@ -12,6 +12,7 @@
         <projectUrl>https://developer.avalara.com</projectUrl>
         <iconUrl>https://developer.avalara.com/public/images/favicon/A-Check-RGB.png</iconUrl>
         <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+        <repository type="git" url="https://github.com/avadev/AvaTax-REST-V2-DotNet-SDK.git" />
 		<copyright>(C) 2004-2019, Avalara, Inc.</copyright>
         <tags>tax Avalara AvaTax sales taxes ecommerce</tags>
         <dependencies>


### PR DESCRIPTION
This PR adds the `<repository />` xml element to the AvaTax nuspec file.
Per the documentation at https://docs.microsoft.com/en-us/nuget/reference/nuspec#repository this will allow direct linking back to the repository from the package. An example of this in action can be seen on the asp.net extension packages (for example [Microsoft.Extensions.Configuration.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Abstractions/))

![image](https://user-images.githubusercontent.com/1991399/76242311-e4719500-620c-11ea-9291-7cb12a1aa40f.png)

The link to the repository shows below the project website on nuget.org.
