### PR TITLE
Build tax content file for location async

### DIFF
--- a/src/AvaTaxApi.cs
+++ b/src/AvaTaxApi.cs
@@ -18226,13 +18226,21 @@ namespace Avalara.AvaTax.RestClient
         /// * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, CompanyAdmin, CompanyUser, Compliance Root User, ComplianceAdmin, ComplianceUser, CSPAdmin, CSPTester, FirmAdmin, FirmUser, ProStoresOperator, Registrar, SiteAdmin, SSTAdmin, SystemAdmin, TechnicalSupportAdmin, TechnicalSupportUser, TreasuryAdmin, TreasuryUser.
         /// * This API depends on the following active services:*Required* (all): AvaTaxPro.;
         /// </remarks>
+        /// 
+        /// <remarks>
+        /// Josh Waldrep - jwaldrepwork@gmail.com - 04/2021 
+        /// This method always fails. The route specified does not return a FileResult it returns a list of tax authorities and rates
+        /// I was unable to find a model that matched the response so one was added. If an existing model is more appropriate it 
+        /// probably should be used
+        /// </remarks>
+        /// 
         /// <param name="companyId">The ID number of the company that owns this location.</param>
         /// <param name="id">The ID number of the location to retrieve point-of-sale data.</param>
         /// <param name="date">The date for which point-of-sale data would be calculated (today by default)</param>
         /// <param name="format">The format of the file (JSON by default)</param>
         /// <param name="partnerId">If specified, requests a custom partner-formatted version of the file.</param>
         /// <param name="includeJurisCodes">When true, the file will include jurisdiction codes in the result.</param>
-        public async Task<FileResult> BuildTaxContentFileForLocationAsync(Int32 companyId, Int32 id, DateTime? date, PointOfSaleFileType? format, PointOfSalePartnerId? partnerId, Boolean? includeJurisCodes)
+        public async Task<List<LocationTaxContent>> BuildTaxContentFileForLocationAsync(Int32 companyId, Int32 id, DateTime? date, PointOfSaleFileType? format, PointOfSalePartnerId? partnerId, Boolean? includeJurisCodes)
         {
             var path = new AvaTaxPath("/api/v2/companies/{companyId}/locations/{id}/pointofsaledata");
             path.ApplyField("companyId", companyId);
@@ -18241,7 +18249,7 @@ namespace Avalara.AvaTax.RestClient
             path.AddQuery("format", format);
             path.AddQuery("partnerId", partnerId);
             path.AddQuery("includeJurisCodes", includeJurisCodes);
-            return await RestCallAsync<FileResult>("GET", path, null).ConfigureAwait(false);
+            return await RestCallAsync<List<LocationTaxContent>>("GET", path, null).ConfigureAwait(false);
         }
 
 

--- a/src/Avalara.AvaTax.net461.csproj
+++ b/src/Avalara.AvaTax.net461.csproj
@@ -312,6 +312,7 @@
     <Compile Include="models\LocationParameterModel.cs" />
     <Compile Include="models\LocationQuestionModel.cs" />
     <Compile Include="models\LocationSettingModel.cs" />
+    <Compile Include="models\LocationTaxContent.cs" />
     <Compile Include="models\LocationValidationModel.cs" />
     <Compile Include="models\LockTransactionModel.cs" />
     <Compile Include="models\LoginVerificationInputModel.cs" />

--- a/src/models/LocationTaxContent.cs
+++ b/src/models/LocationTaxContent.cs
@@ -1,0 +1,50 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Avalara.AvaTax.RestClient
+{
+    /// <summary>
+    /// Simple POCO  + ToString() object to hold the tax information returned by the BuildTaxContentFileForLocationAsync 
+    /// methods in AvaTaxClient 
+    /// </summary>
+    /// 
+    /// <remarks>
+    /// Josh Waldrep - jwaldrepwork@gmail.com - 04/2021
+    /// The datatypes here were derived from the response to the api route "/api/v2/companies/{companyId}/locations/{id}/pointofsaledata" 
+    /// and need to be reviewed and commented.
+    /// </remarks>
+    public class LocationTaxContent
+    {
+        public Int32? ScenarioId { get; set; }
+        public DateTime? EffDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public String LocationCode { get; set; }
+        public String TaxCode { get; set; }
+        public String ShipToCity { get; set; }
+        public String ShipToCounty { get; set; }
+        public String ShipToState { get; set; }
+        public String ShipToPostalCode { get; set; }
+        public String ShipToCountry { get; set; }
+        public String JurisType { get; set; }
+        public String JurisName { get; set; }
+        public String TaxType { get; set; }
+        public String Tax_Description { get; set; }
+        public decimal? Tax_Rate { get; set; }
+        public String Cap { get; set; }
+        public String Threshold { get; set; }
+        public String TaxRuleOptions { get; set; }
+
+        /// <summary>
+        /// Convert this object to a JSON string of itself
+        /// </summary>
+        /// <returns>A JSON string of this object</returns>
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this, new JsonSerializerSettings() { Formatting = Formatting.Indented });
+        }
+    }
+}


### PR DESCRIPTION
Fixes the incorrect deserialization of the BuildTaxContentFileForLocationAsync method. The response is an array of tax locations, item codes, and rates. The SDK is trying to deserialize it into a FileResult Object. The call always fails on the deserialization. 

I couldn't find a class that matched the return values of the API so I added one. If there is an existing class, that would probably be better. I had to assume the data types based on the values returned by calling the API directly and looking through the other model classes.

I don't know Avalara's documentation standards so there will probably be some updates needed before this is merged.

I didn't find anything in the tests project that references this method.