### PR TITLE
Use 'RestCallFileAsync' instead of 'RestCallAsync' in DownloadBatchAsync

### DIFF
--- a/src/AvaTaxApi.cs
+++ b/src/AvaTaxApi.cs
@@ -11145,7 +11145,7 @@ namespace Avalara.AvaTax.RestClient
             path.ApplyField("companyId", companyId);
             path.ApplyField("batchId", batchId);
             path.ApplyField("id", id);
-            return await RestCallAsync<FileResult>("GET", path, null).ConfigureAwait(false);
+            return await RestCallFileAsync("GET", path, null).ConfigureAwait(false);
         }
 
 


### PR DESCRIPTION
DownloadBatchAsync always throws parser exception, and uses RestCallAsync<FileResult>.
DownloadBatch, on the other hand uses RestCallFile (Which still calls RestCallFileAsync), and works without any problem.
I suggest making these two functions to use the same logic, at least for the sake of consistency.
This quick fix makes them work the same, and seems to solve the problem(I used changed version as the reference to run tests - no exceptions thrown).