### PR TITLE
APIPLAT-4564:Update TransactionBuilder to use entityUseCode and deprecate customerUsageType

### DIFF
--- a/src/TransactionBuilder.cs
+++ b/src/TransactionBuilder.cs
@@ -372,18 +372,19 @@ namespace Avalara.AvaTax.RestClient
         }
 
         /// <summary>
+        /// This method is deprecated, please use WithTaxIncludeLineItem instead.
 		/// Add a line to this transaction with tax included
 		/// </summary>
 		/// <param name="amount">Value of the item.</param>
 		/// <param name="quantity">Quantity of the item.</param>
 		/// <param name="taxCode">Tax Code of the item. If left blank, the default item (P0000000) is assumed.  Use ListTaxCodes() for a list of values.</param>
-		/// <param name="customerUsageType">"customerUsageType" is depricated, use "entityUseCode" instead. The intended usage type for this line.  Use ListEntityUseCodes() for a list of values.</param>
+		/// <param name="customerUsageType">The intended usage type for this line.  Use ListEntityUseCodes() for a list of values.</param>
 		/// <param name="description">A friendly description of this line item.</param>
 		/// <param name="itemCode">The item code of this item in your product item definitions.</param>
 		/// <param name="lineNumber">the number of the line.</param>
-        /// <param name="entityUseCode">A specific entity use code for the entire transaction.</param>
 		/// <returns></returns>
-		public TransactionBuilder WithTaxIncludeLine(decimal amount, decimal quantity = 1, string taxCode = null, string description = null, string itemCode = null, string customerUsageType = null, string lineNumber = null, string entityUseCode = null)
+        [Obsolete("This method is deprecated, please use WithTaxIncludeLineItem instead.")]
+        public TransactionBuilder WithTaxIncludeLine(decimal amount, decimal quantity = 1, string taxCode = null, string description = null, string itemCode = null, string customerUsageType = null, string lineNumber = null)
         {
 			string lineNumStr = lineNumber;
 			if(string.IsNullOrEmpty(lineNumStr))
@@ -400,8 +401,84 @@ namespace Avalara.AvaTax.RestClient
                 description = description,
                 itemCode = itemCode,
                 customerUsageType = customerUsageType,
-                taxIncluded = true,
-                entityUseCode = entityUseCode
+                taxIncluded = true
+            };
+
+            _model.lines.Add(l);
+            _line_number++;
+
+            // Continue building
+            return this;
+        }
+
+        /// <summary>
+        /// Add a line to this transaction with tax included
+        /// </summary>
+        /// <param name="amount">Value of the item.</param>
+        /// <param name="quantity">Quantity of the item.</param>
+        /// <param name="taxCode">Tax Code of the item. If left blank, the default item (P0000000) is assumed.  Use ListTaxCodes() for a list of values.</param>
+        /// <param name="description">A friendly description of this line item.</param>
+        /// <param name="itemCode">The item code of this item in your product item definitions.</param>
+        /// <param name="lineNumber">the number of the line.</param>
+        /// <param name="entityUseCode">A specific entity use code for the entire transaction.</param>
+        /// <returns></returns>
+        public TransactionBuilder WithTaxIncludeLineItem(decimal amount, decimal quantity = 1, string taxCode = null, string description = null, string itemCode = null, string lineNumber = null, string entityUseCode = null)
+        {
+            string lineNumStr = lineNumber;
+            if (string.IsNullOrEmpty(lineNumStr))
+            {
+                lineNumStr = _line_number.ToString();
+            }
+
+            var l = new LineItemModel
+            {
+                number = lineNumStr,
+                quantity = quantity,
+                amount = amount,
+                taxCode = taxCode,
+                description = description,
+                itemCode = itemCode,
+                entityUseCode = entityUseCode,
+                taxIncluded = true
+            };
+
+            _model.lines.Add(l);
+            _line_number++;
+
+            // Continue building
+            return this;
+        }
+
+        /// <summary>
+        /// This method is deprecated, please use WithLineItem instead.
+        /// Add a line to this transaction
+        /// </summary>
+        /// <param name="amount">Value of the item.</param>
+        /// <param name="quantity">Quantity of the item.</param>
+        /// <param name="taxCode">Tax Code of the item. If left blank, the default item (P0000000) is assumed.  Use ListTaxCodes() for a list of values.</param>
+        /// <param name="customerUsageType">The intended usage type for this line.  Use ListEntityUseCodes() for a list of values.</param>
+        /// <param name="description">A friendly description of this line item.</param>
+        /// <param name="itemCode">The item code of this item in your product item definitions.</param>
+        /// <param name="lineNumber">the number of the line.</param>
+        /// <returns></returns>
+        [Obsolete("This method is deprecated, please use WithLineItem instead.")]
+        public TransactionBuilder WithLine(decimal amount, decimal quantity = 1, string taxCode = null, string description = null, string itemCode = null, string customerUsageType = null, string lineNumber = null)
+        {
+			string lineNumStr = lineNumber;
+			if(string.IsNullOrEmpty(lineNumStr))
+			{
+				lineNumStr = _line_number.ToString();
+			}
+	
+            var l = new LineItemModel
+            {
+                number = lineNumStr,
+                quantity = quantity,
+                amount = amount,
+                taxCode = taxCode,
+                description = description,
+                itemCode = itemCode,
+                customerUsageType = customerUsageType
             };
 
             _model.lines.Add(l);
@@ -417,20 +494,19 @@ namespace Avalara.AvaTax.RestClient
         /// <param name="amount">Value of the item.</param>
         /// <param name="quantity">Quantity of the item.</param>
         /// <param name="taxCode">Tax Code of the item. If left blank, the default item (P0000000) is assumed.  Use ListTaxCodes() for a list of values.</param>
-        /// <param name="customerUsageType">"customerUsageType" is depricated, use "entityUseCode" instead. The intended usage type for this line.  Use ListEntityUseCodes() for a list of values.</param>
         /// <param name="description">A friendly description of this line item.</param>
         /// <param name="itemCode">The item code of this item in your product item definitions.</param>
         /// <param name="lineNumber">the number of the line.</param>
         /// <param name="entityUseCode">A specific entity use code for the entire transaction.</param>
         /// <returns></returns>
-        public TransactionBuilder WithLine(decimal amount, decimal quantity = 1, string taxCode = null, string description = null, string itemCode = null, string customerUsageType = null, string lineNumber = null, string entityUseCode = null)
+        public TransactionBuilder WithLineItem(decimal amount, decimal quantity = 1, string taxCode = null, string description = null, string itemCode = null, string lineNumber = null, string entityUseCode = null)
         {
-			string lineNumStr = lineNumber;
-			if(string.IsNullOrEmpty(lineNumStr))
-			{
-				lineNumStr = _line_number.ToString();
-			}
-	
+            string lineNumStr = lineNumber;
+            if (string.IsNullOrEmpty(lineNumStr))
+            {
+                lineNumStr = _line_number.ToString();
+            }
+
             var l = new LineItemModel
             {
                 number = lineNumStr,
@@ -439,7 +515,6 @@ namespace Avalara.AvaTax.RestClient
                 taxCode = taxCode,
                 description = description,
                 itemCode = itemCode,
-                customerUsageType = customerUsageType,
                 entityUseCode = entityUseCode
             };
 

--- a/tests/net20/TransactionTests.cs
+++ b/tests/net20/TransactionTests.cs
@@ -112,8 +112,8 @@ namespace Tests.Avalara.AvaTax.RestClient.net20
             var transaction = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice, "ABC")
                 .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
                     "98104", "US")
-                .WithLine(100.0m, 1, "P0000000")
-                .WithLine(200m)
+                .WithLineItem(100.0m, 1, "P0000000")
+                .WithLineItem(200m)
                 .WithExemptLine(50m, "NT")
                 .WithLineReference("Special Line Reference!", "Also this!")
                 .Create();
@@ -177,8 +177,8 @@ namespace Tests.Avalara.AvaTax.RestClient.net20
                     "TaxOverrideCustomerCode")
                 .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
                     "98104", "US")
-                .WithLine(100.0m, 1, "P0000000")
-                .WithLine(200m);
+                .WithLineItem(100.0m, 1, "P0000000")
+                .WithLineItem(200m);
 
 
             var transaction = builder.Create();


### PR DESCRIPTION
With this change, we will deprecate the customerUsageType and suggest to use entityUseCode instead. 
The method name "WithUsageType" in TransactionBuilder is marked "Deprecated"