### PR TITLE
Add dotnet 6 and dotnet 8 targets

### DIFF
--- a/Avalara.AvaTax.RestClient.sln
+++ b/Avalara.AvaTax.RestClient.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalara.AvaTax.RestClient", "src\Avalara.AvaTax.RestClient.csproj", "{F0EEC671-76CD-47C3-8671-FA178139B2A9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalara.AvaTax.RestClient.Test", "tests\Avalara.AvaTax.RestClient.Test.csproj", "{88267F39-00E4-4D70-8E76-EA601E43CCA0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F0EEC671-76CD-47C3-8671-FA178139B2A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0EEC671-76CD-47C3-8671-FA178139B2A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0EEC671-76CD-47C3-8671-FA178139B2A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0EEC671-76CD-47C3-8671-FA178139B2A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88267F39-00E4-4D70-8E76-EA601E43CCA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88267F39-00E4-4D70-8E76-EA601E43CCA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88267F39-00E4-4D70-8E76-EA601E43CCA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88267F39-00E4-4D70-8E76-EA601E43CCA0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EF80143E-E986-4C4B-9401-395AF44EF2FE}
+	EndGlobalSection
+EndGlobal

--- a/Avalara.AvaTax.RestClient.sln
+++ b/Avalara.AvaTax.RestClient.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalara.AvaTax.RestClient", "src\Avalara.AvaTax.RestClient.csproj", "{F0EEC671-76CD-47C3-8671-FA178139B2A9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalara.AvaTax.RestClient.Test", "tests\Avalara.AvaTax.RestClient.Test.csproj", "{88267F39-00E4-4D70-8E76-EA601E43CCA0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalara.AvaTax.RestClient.Tests", "tests\Avalara.AvaTax.RestClient.Tests.csproj", "{88267F39-00E4-4D70-8E76-EA601E43CCA0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/AvaTaxOfflineHelper.cs
+++ b/src/AvaTaxOfflineHelper.cs
@@ -145,7 +145,8 @@ namespace Avalara.AvaTax.RestClient
             TextWriter writer = null;
 
             try {
-                Directory.GetAccessControl(path);
+                DirectoryInfo directory = new DirectoryInfo(path);
+                directory.GetAccessControl();
                 var content = JsonConvert.SerializeObject(zipRate);
                 writer = new StreamWriter(Path.Combine(path, zip + ".json"));
                 writer.Write(content);

--- a/src/Avalara.AvaTax.RestClient.csproj
+++ b/src/Avalara.AvaTax.RestClient.csproj
@@ -57,32 +57,32 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>TRACE;DEBUG;PORTABLE;NETSTANDARD2_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NETSTANDARD2_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>TRACE;DEBUG;PORTABLE;NET6_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NET6_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>TRACE;DEBUG;PORTABLE;NET8_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NET8_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>

--- a/src/Avalara.AvaTax.RestClient.csproj
+++ b/src/Avalara.AvaTax.RestClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net20;net45;net461;net472;netstandard1.6;netstandard2.0</TargetFrameworks>
 		<DelaySign>false</DelaySign>
+		<TargetFrameworks>net20;net45;net461;net472;netstandard1.6;netstandard2.0;net6.0</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>Avalara.AvaTax.RestClient.snk</AssemblyOriginatorKeyFile>
@@ -64,6 +64,16 @@
 	
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NETSTANDARD2_0</DefineConstants>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
+	
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<DefineConstants>TRACE;DEBUG;PORTABLE;NET6_0</DefineConstants>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
+	
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<DefineConstants>TRACE;RELEASE;PORTABLE;NET6_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 

--- a/src/Avalara.AvaTax.RestClient.csproj
+++ b/src/Avalara.AvaTax.RestClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<DelaySign>false</DelaySign>
-		<TargetFrameworks>net20;net45;net461;net472;netstandard1.6;netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net20;net45;net461;net472;netstandard1.6;netstandard2.0;net6.0;net8.0</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>Avalara.AvaTax.RestClient.snk</AssemblyOriginatorKeyFile>
@@ -76,6 +76,16 @@
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NET6_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
+	
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<DefineConstants>TRACE;DEBUG;PORTABLE;NET8_0</DefineConstants>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
+	
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<DefineConstants>TRACE;RELEASE;PORTABLE;NET8_0</DefineConstants>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
 
 	<ItemGroup>
@@ -115,6 +125,14 @@
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	</ItemGroup>

--- a/src/Avalara.AvaTax.RestClient.csproj
+++ b/src/Avalara.AvaTax.RestClient.csproj
@@ -74,39 +74,39 @@
 		<Folder Include="models" />		
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net20'">
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<Compile Include="..\GlobalAssemblyInfo.cs">
 			<Link>Properties\GlobalAssemblyInfo.cs</Link>
 		</Compile>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<Reference Include="System.Net.Http" />
 		<Compile Include="..\GlobalAssemblyInfo.cs">
 			<Link>Properties\GlobalAssemblyInfo.cs</Link>
 		</Compile>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<Reference Include="System.Net.Http" />
 		<Compile Include="..\GlobalAssemblyInfo.cs">
 			<Link>Properties\GlobalAssemblyInfo.cs</Link>
 		</Compile>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="System.Net.Http" Version="4.3.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<Compile Include="..\GlobalAssemblyInfo.cs">
 			<Link>Properties\GlobalAssemblyInfo.cs</Link>
 		</Compile>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="System.Net.Http" Version="4.3.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="System.Net.Http" Version="4.3.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	</ItemGroup>
 	<ItemGroup>
     

--- a/src/Avalara.AvaTax.RestClient.csproj
+++ b/src/Avalara.AvaTax.RestClient.csproj
@@ -6,7 +6,9 @@
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>Avalara.AvaTax.RestClient.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>
+
 	
+	<!-- .NET Framework 2.0 -->
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net20' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>NETFRAMEWORK;TRACE;DEBUG;NET20</DefineConstants>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -15,8 +17,9 @@
 		<DefineConstants>NETFRAMEWORK;TRACE;RELEASE;NET20</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
-	
+
+
+	<!-- .NET Framework 4.5 -->
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net45' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>NETFRAMEWORK;TRACE;DEBUG;PORTABLE;NET45</DefineConstants>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -25,8 +28,9 @@
 		<DefineConstants>NETFRAMEWORK;TRACE;RELEASE;PORTABLE;NET45</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
+
 	
-	
+	<!-- .NET Framework 4.6.1 -->
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net461' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>NETFRAMEWORK;TRACE;DEBUG;PORTABLE;NET461</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -35,108 +39,85 @@
 		<DefineConstants>NETFRAMEWORK;TRACE;RELEASE;PORTABLE;NET461</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
+
 	
-	
+	<!-- .NET Framework 4.7.2 -->
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net472' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>NETFRAMEWORK;TRACE;DEBUG;PORTABLE;NET472</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net472' AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
 		<DefineConstants>NETFRAMEWORK;TRACE;RELEASE;PORTABLE;NET472</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
+
+
+	<!-- .NET Standard 1.6 -->
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>TRACE;DEBUG;PORTABLE;NETSTANDARD1_6</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6' AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NETSTANDARD1_6</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
+
 	
+	<!-- .NET Standard 2.0 -->
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>TRACE;DEBUG;PORTABLE;NETSTANDARD2_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NETSTANDARD2_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
+
+
+	<!-- .NET 6.0 -->
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>TRACE;DEBUG;PORTABLE;NET6_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NET6_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
+
+
+	<!-- .NET 8.0 -->
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' AND '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<DefineConstants>TRACE;DEBUG;PORTABLE;NET8_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-	
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' AND '$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
 		<DefineConstants>TRACE;RELEASE;PORTABLE;NET8_0</DefineConstants>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
-
-
+	
+	
 	<ItemGroup>
 		<None Remove="**" />
 		<Folder Include="enums" />
-		<Folder Include="models" />		
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net20'">
+		<Folder Include="models" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<Compile Include="..\GlobalAssemblyInfo.cs">
-			<Link>Properties\GlobalAssemblyInfo.cs</Link>
-		</Compile>
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<Reference Include="System.Net.Http" />
-		<Compile Include="..\GlobalAssemblyInfo.cs">
-			<Link>Properties\GlobalAssemblyInfo.cs</Link>
-		</Compile>
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<Reference Include="System.Net.Http" />
-		<Compile Include="..\GlobalAssemblyInfo.cs">
-			<Link>Properties\GlobalAssemblyInfo.cs</Link>
-		</Compile>
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<Compile Include="..\GlobalAssemblyInfo.cs">
-			<Link>Properties\GlobalAssemblyInfo.cs</Link>
-		</Compile>
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-	</ItemGroup>
-	<ItemGroup>
-    
-  </ItemGroup>
+	
+	
+	<!-- .NET Framework 2.0 doesn't have a System.Net.Http package, so it can't be included-->
+	<Choose>
+		<When Condition="'$(TargetFramework)' == 'net20'">
+			<ItemGroup>
+				<Compile Include="..\GlobalAssemblyInfo.cs">
+					<Link>Properties\GlobalAssemblyInfo.cs</Link>
+				</Compile>
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+				<PackageReference Include="System.Net.Http" Version="4.3.4" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
 </Project>

--- a/tests/Avalara.AvaTax.RestClient.Test.csproj
+++ b/tests/Avalara.AvaTax.RestClient.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net451;net45;net461;net472;netcoreapp2.2.8;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net451;net45;net461;net472;netcoreapp2.2.8;netcoreapp3.1;net6.0</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net451'">
@@ -14,6 +14,8 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Remove="**\*.*" />
@@ -63,7 +65,7 @@
 		  <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2.8'">
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
@@ -83,6 +85,17 @@
 		<Compile Include="netstandard20\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Nunit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<Compile Include="net6.0\*.cs" />
+		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
+		  <SetTargetFramework>TargetFramework=net6.0</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
 </Project>

--- a/tests/Avalara.AvaTax.RestClient.Test.csproj
+++ b/tests/Avalara.AvaTax.RestClient.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net451;net45;net461;net472;netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net451;net45;net461;net472;netcoreapp2.2.8;netcoreapp3.1</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net451'">
@@ -20,10 +20,10 @@
 		<None Remove="**" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net451'">
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 		<Reference Include="System.Net.Http" />
 		<Compile Include="net20\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
@@ -31,7 +31,7 @@
 		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
@@ -42,7 +42,7 @@
 		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
@@ -53,8 +53,8 @@
 		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="System.Net.Http" Version="4.3.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
@@ -64,22 +64,22 @@
 		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.2" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<Compile Include="netstandard\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=netstandard1.6</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.2" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<Compile Include="netstandard20\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>

--- a/tests/Avalara.AvaTax.RestClient.Test.csproj
+++ b/tests/Avalara.AvaTax.RestClient.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net451;net45;net461;net472;netcoreapp2.2.8;netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>net451;net45;net461;net472;netcoreapp2.2.8;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net451'">
@@ -16,6 +16,8 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Remove="**\*.*" />
@@ -88,6 +90,17 @@
 		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Nunit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<Compile Include="net6.0\*.cs" />
+		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
+		  <SetTargetFramework>TargetFramework=net6.0</SetTargetFramework>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/tests/Avalara.AvaTax.RestClient.Test.csproj
+++ b/tests/Avalara.AvaTax.RestClient.Test.csproj
@@ -3,109 +3,74 @@
 		<TargetFrameworks>net451;net45;net461;net472;netcoreapp2.2.8;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net451'">
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
-	</PropertyGroup>
+	
 	<ItemGroup>
-		<Compile Remove="**\*.*" />
-		<None Remove="**" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net451'">
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Nunit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-		<Reference Include="System.Net.Http" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
+
+
+	<!-- .NET Framework 4.5.1 -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net451'">
 		<Compile Include="net20\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=net20</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
+
+	<!-- .NET Framework 4.5 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<Reference Include="System.Net.Http" />
 		<Compile Include="net45\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=net45</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
+
+	<!-- .NET Framework 4.6.1 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<Reference Include="System.Net.Http" />
 		<Compile Include="net461\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
+	
+	<!-- .NET Framework 4.7.2 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="Nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
 		<Compile Include="net472\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
+
+	<!-- .NET Core 2.2.8 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2.8'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="NUnit" Version="3.12.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<Compile Include="netstandard\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=netstandard1.6</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
+
+	<!-- .NET Core 3.1 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<Compile Include="netstandard20\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
+
+	<!-- .NET 6.0 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<Compile Include="net6.0\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=net6.0</SetTargetFramework>
 		</ProjectReference>
 	</ItemGroup>
+
+	<!-- .NET 8.0 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<Compile Include="net6.0\*.cs" />
 		<ProjectReference Include="..\src\Avalara.AvaTax.RestClient.csproj">
 		  <SetTargetFramework>TargetFramework=net6.0</SetTargetFramework>

--- a/tests/net6.0/BatchTests.cs
+++ b/tests/net6.0/BatchTests.cs
@@ -1,0 +1,198 @@
+﻿using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    [TestFixture]
+    public class BatchTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try
+            {
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(typeof(TransactionTests).Name,
+                    typeof(TransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString("N").Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Hardware Store",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay after creating a company
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public async Task BatchesWorkflow()
+        {
+            // Raw batch CSV string.
+            const string transactionImport = @"ProcessCode,DocCode,DocType,DocDate,CompanyCode,CustomerCode,EntityUseCode,LineNo,TaxCode,TaxDate,ItemCode,Description,Qty,Amount,Discount,Ref1,Ref2,ExemptionNo,RevAcct,DestAddress,DestCity,DestRegion,DestPostalCode,DestCountry,OrigAddress,OrigCity,OrigRegion,OrigPostalCode,OrigCountry,LocationCode,SalesPersonCode,PurchaseOrderNo,CurrencyCode,ExchangeRate,ExchangeRateEffDate,PaymentDate,TaxIncluded,DestTaxRegion,OrigTaxRegion,Taxable,TaxType,TotalTax,CountryName,CountryCode,CountryRate,CountryTax,StateName,StateCode,StateRate,StateTax,CountyName,CountyCode,CountyRate,CountyTax,CityName,CityCode,CityRate,CityTax,Other1Name,Other1Code,Other1Rate,Other1Tax,Other2Name,Other2Code,Other2Rate,Other2Tax,Other3Name,Other3Code,Other3Rate,Other3Tax,Other4Name,Other4Code,Other4Rate,Other4Tax,ReferenceCode,BuyersVATNo
+3,BS1323154187029MG10,2,16-Apr-14,,029MG10,,0000000001,SR060100,06-May-14,6500,REPAIRS & MAINTENANCE,,1980,,,0,,6500,119 N. 72nd St.,Omaha,NE,68114,,6923 MAPLE ST,OMAHA,NE,68104,,029,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS1323158772194036MAC1,2,04-Apr-14,,036MAC1,,0000000001,SC150158,06-May-14,6505,R&M HEAT / VENT / AIR COND,,322.26,,,0,,6505,1200 E. Mall Drive,Holland,OH,43528,,2875 CRANE WAY,NORTHWOOD,OH,43619,,036,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS1323159W206409036MLK,2,25-Mar-14,,036MLK,,0000000001,SR060100,06-May-14,6507,R&M OTHER,,449,,,31.43,,6507,1200 E. Mall Drive,Holland,OH,43528,,1214 JEFFERSON AVE,TOLEDO,OH,43604,,036,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231601596048MRP2,2,02-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,60,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231631591048MRP2,2,02-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,58,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231611594048MRP2,2,01-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,65,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231621593048MRP2,2,01-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,75,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231641587048MRP2,2,01-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,60,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231651582048MRP2,2,15-Mar-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,47,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,";
+
+            // Let's Create the file portion of the batch request.
+            var batchFileModel = new BatchFileModel
+            {
+                name = "TransactionImport.csv",
+                content = Encoding.UTF8.GetBytes(transactionImport),
+                contentType = "text/csv",
+                fileExtension = "csv"
+            };
+
+            // Create the bare-minimum batch header info.
+            var batchRequest = new BatchModel
+            {
+                name = "AutomationTestBatch",
+                type = BatchType.TransactionImport,
+                files = new List<BatchFileModel> { batchFileModel }
+            };
+
+            // Send the batch!
+            try
+            {
+                var batchResult = Client.CreateBatches(TestCompany.id, new List<BatchModel> { batchRequest });
+                Assert.NotNull(batchResult, "Batch not sent.");
+                Assert.True(batchResult.Count > 0, "No batches created.");
+
+                // Check that the batch comes out of Waiting state using a linear backoff strategy.
+                var waiting = true;
+                BatchModel batchFetchResult = null;
+                for (var i = 1; i < 6; ++i)
+                {
+                    await Task.Delay(i * 1000);
+
+                    batchFetchResult = Client.GetBatch(TestCompany.id, batchResult[0].id.Value);
+                    Assert.NotNull(batchFetchResult, "Batch fetch unsuccessful.");
+                    if (batchFetchResult.status.Value == BatchStatus.Waiting) continue;
+                    waiting = false;
+                    break;
+                }
+                Assert.True(waiting == false, $"Batch waiting too long. Check BatchId: {batchResult[0].id}");
+
+                // This batch is no longer in the Waiting state. Let's see it process.
+                var processing = true;
+                for (var i = 1; i < 11; ++i)
+                {
+                    await Task.Delay(i * 1000);
+
+                    batchFetchResult = Client.GetBatch(TestCompany.id, batchResult[0].id.Value);
+                    Assert.NotNull(batchFetchResult, "Batch fetch unsuccessful.");
+                    if (batchFetchResult.status.Value == BatchStatus.Processing) continue;
+                    processing = false;
+                    break;
+                }
+                Assert.True(processing == false, $"Batch processing too long. Check BatchId: {batchResult[0].id}");
+
+                // This batch is done processing. 
+                Assert.True((batchFetchResult.status.Value == BatchStatus.Errors || batchFetchResult.status.Value == BatchStatus.Completed),
+                    $"BatchId: {batchResult[0].id} should either complete or error out.");
+                // Ensure that the number of records matches what we sent in.
+                Assert.AreEqual(9, batchFetchResult.currentRecord.Value);
+
+                // Alright. Time to download the sent batch file.
+                var fileResult = Client.DownloadBatch(TestCompany.id, batchFetchResult.id.Value, batchFetchResult.files[0].id.Value);
+                Assert.NotNull(fileResult);
+
+                // Compare what we got back with what we sent.
+                Assert.AreEqual(batchFetchResult.name + ".Input.CSV; filename*=UTF-8''" + batchFetchResult.name + ".Input.CSV", fileResult.Filename);
+                Assert.AreEqual(batchFileModel.content, fileResult.Data);
+                Assert.AreEqual(batchFileModel.contentType, fileResult.ContentType);
+            } catch (AvaTaxError e)
+            {
+                Assert.True(false, $"AvaTaxError: {e.error.error.details?[0].message}");
+            } catch (Exception e)
+            {
+                Assert.True(false, $"Unknown Exception! {e.Message}");
+            }
+        }
+    }
+}

--- a/tests/net6.0/CertificateTests.cs
+++ b/tests/net6.0/CertificateTests.cs
@@ -1,0 +1,144 @@
+﻿using Avalara.AvaTax.RestClient;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Net;
+using System.Reflection;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    [TestFixture]
+    public class CertificateTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public int DefaultCompanyId { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try {
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(typeof(CertificateTests).Name,
+                    typeof(CertificateTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                //Get the default company.
+                var defaultCompanyModel = Client.QueryCompanies(string.Empty, "isDefault EQ true", null, null, string.Empty).value[0];
+
+                DefaultCompanyId = defaultCompanyModel.id;
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString().Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Greatest Popcorn",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex) {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try {
+
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex) {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// Tests the upload certificate image endpoint.
+        /// </summary>
+        [Test]
+        [Ignore("Ignore CertificateImageUploadTest")]
+        public void CertificateImageUploadTest()
+        {
+            //Get the cert number. The account needs to have CertCapture 
+            //be provisioned, already have a certificate created, and the
+            //certificate needs to be valid.
+            var certs = Client.QueryCertificates(DefaultCompanyId, string.Empty, "valid EQ true", null, null, string.Empty).value;
+            var certId = certs[0].id.Value;
+
+            //Get an image.
+            byte[] jpegByteArr = File.ReadAllBytes(Environment.GetEnvironmentVariable("TEST_IMAGE_PATH"));
+
+            FileResult fileResult = new FileResult()
+            {
+                ContentType = "multipart/form-data",
+                Filename = "test_cert_image.jpg",
+                Data = jpegByteArr
+            };
+
+            //Send request.
+            var certUploadResult = Client.UploadCertificateImage(DefaultCompanyId, certId, fileResult);
+
+            //Response should be "OK"
+            Assert.True(string.Equals(certUploadResult, "\"OK\""));
+
+            //Test download of image attachment.
+            var certAttachment = Client.DownloadCertificateImage(DefaultCompanyId, certId, null, CertificatePreviewType.Pdf);
+            Assert.NotNull(certAttachment);
+            Assert.True(string.Equals(certAttachment.ContentType, "application/pdf"));
+            Assert.True(certAttachment.Data.Length > 1000);
+            
+        }
+    }
+}

--- a/tests/net6.0/ErrorResultTests.cs
+++ b/tests/net6.0/ErrorResultTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    [TestFixture]
+    public class ErrorResultTests : TestBase
+    {
+        [Test]
+        public async Task NonJsonErrorResult()
+        {
+            AvaTaxError avataxError = null;
+            try
+            {
+                // make a client that points to a server that will give a 404 for ping
+                var client = new AvaTaxClient(GetType().Name,
+                        GetType().GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                        Environment.MachineName, new Uri("https://www.google.com"));
+
+                var result = await client.PingAsync().ConfigureAwait(false);
+            }
+            catch (AvaTaxError e)
+            {
+                avataxError = e;
+            }
+
+            Assert.NotNull(avataxError);
+            Assert.True(avataxError.error.error.message.Contains("the response is in an unexpected format"));
+            Assert.True(avataxError.error.error.details[0].description.ToLower().Contains("not found"));
+        }
+
+        [Test]
+        public async Task JsonErrorResult()
+        {
+            AvaTaxError avataxError = null;
+            try
+            {
+                var result = await _client.ChangePasswordAsync(new PasswordChangeModel
+                {
+                }).ConfigureAwait(false);
+            }
+            catch (AvaTaxError e)
+            {
+                avataxError = e;
+            }
+
+            Assert.NotNull(avataxError);
+            Assert.True(avataxError.error.error.message.Contains("Field oldPassword is required"));
+        }
+    }
+}

--- a/tests/net6.0/FreeTaxRatesTest.cs
+++ b/tests/net6.0/FreeTaxRatesTest.cs
@@ -1,0 +1,97 @@
+﻿using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    [TestFixture]
+    class FreeTaxRatesTest
+    {
+        public AvaTaxClient _client;
+
+        #region Setup / Teardown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try {
+                // Create a client and set up authentication
+                _client = new AvaTaxClient(typeof(TransactionTests).Name,
+                typeof(TransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                Environment.MachineName,
+                AvaTaxEnvironment.Sandbox)
+                .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+            } catch (Exception ex) {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+        #endregion
+
+        [Test]
+        public async Task FreeTaxRates()
+        {
+            // Call TaxRates for a few addresses and verify that the rates are nonzero
+            var tr = await _client.TaxRatesByAddressAsync("123 Main Street", null, null, "Irvine", "CA", "92615", "US");
+            Assert.NotNull(tr);
+            Assert.True(tr.totalRate > 0.05m);
+
+            // Washington
+            tr = await _client.TaxRatesByAddressAsync("522 Stadium Pl S", null, null, "Seattle", "WA", "98104", "US");
+            Assert.NotNull(tr);
+            Assert.True(tr.totalRate > 0.05m);
+
+            // By postal code for New York
+            tr = await _client.TaxRatesByPostalCodeAsync("US", "10010");
+            Assert.NotNull(tr);
+            Assert.True(tr.totalRate > 0.05m);
+        }
+
+        /// <summary>
+        /// Test the local rate by ZIP storage and retrieval.
+        /// </summary>        
+        [Test]
+        [Ignore("This test will fail in Travis")]
+        public void StoreRatesByZipTest()
+        {
+            string path = Environment.GetEnvironmentVariable("ZIP_RATE_FILE_STORAGE_PATH");
+            List<string> zips = new List<string>() { "12590", "98104" };
+
+            //Call the content caching helper.
+            AvaTaxOfflineHelper.StoreZipRateContent(_client, "US", zips, path);
+
+            //Verify that the files were stored locally. 
+            bool zipRateExists = AvaTaxOfflineHelper.VerifyLocalZipRateAvailable(zips[0], path);
+            Assert.True(zipRateExists);
+            zipRateExists = AvaTaxOfflineHelper.VerifyLocalZipRateAvailable(zips[1], path);
+            Assert.True(zipRateExists);
+
+            //Verify that a bogus file does not exist locally.
+            zipRateExists = AvaTaxOfflineHelper.VerifyLocalZipRateAvailable("bogusZipFile.json", path);
+            Assert.False(zipRateExists);
+
+            //Verify that the local file can be used for rate calculation.
+            var zipTaxRate = AvaTaxOfflineHelper.GetLocalTaxRateByZip(zips[1], path);
+            Assert.NotNull(zipTaxRate);
+            decimal result = 9.99m * zipTaxRate.totalRate.Value;
+            Assert.NotZero(result);
+
+            //Test AvaTaxOfflineHelper Exception handling.
+            path = @"n:\someBadPath";
+            try {
+                AvaTaxOfflineHelper.StoreZipRateContent(_client, "US", zips, path);
+            } catch (AvaTaxOfflineHelperException exc) {
+#if PORTABLE
+                Assert.True(string.Equals(exc.InnerException.Message, "Could not find a part of the path 'n:\\someBadPath\\12590.json'."));
+#else
+                Assert.True(string.Equals(exc.Message, "An error occurred retrieving or storing the rate content. Please see inner exception for details."));
+#endif
+            }
+        }
+    }
+}

--- a/tests/net6.0/HttpClientTransactionTests.cs
+++ b/tests/net6.0/HttpClientTransactionTests.cs
@@ -1,0 +1,204 @@
+﻿using Avalara.AvaTax.RestClient;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Reflection;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    [TestFixture]
+    public class HttpClientTransactionTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try
+            {
+                var httpClient = new System.Net.Http.HttpClient() { Timeout = TimeSpan.FromMinutes(20) };
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(httpClient, typeof(HttpClientTransactionTests).Name,
+                    typeof(HttpClientTransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString().Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Greatest Popcorn",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// To debug this application, call app must be called with args[0] as username and args[1] as password
+        /// </summary>
+        [Test]
+		public void TransactionWorkflow()
+        {
+            Client.CallCompleted += Client_CallCompleted;
+            var tfn = System.IO.Path.GetTempFileName();
+            Client.LogToFile(tfn);
+
+            // Execute a transaction
+            var transaction = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice, "ABC")
+                .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
+                    "98104", "US")
+                .WithLine(100.0m, 1, "P0000000")
+                .WithLine(200m)
+                .WithExemptLine(50m, "NT")
+                .WithLineReference("Special Line Reference!", "Also this!")
+                .Create();
+
+            // Verify that the call was captured and logged
+            Assert.NotNull(lastEvent);
+            Assert.True(String.Equals(lastEvent.HttpVerb, "POST", StringComparison.CurrentCultureIgnoreCase));
+            Assert.True(String.Equals(lastEvent.RequestUri.ToString(), "https://sandbox-rest.avatax.com/api/v2/transactions/create", StringComparison.CurrentCultureIgnoreCase));
+            Assert.AreEqual(lastEvent.Code, HttpStatusCode.Created);
+
+            // Verify that the log file was created
+            Assert.True(System.IO.File.Exists(tfn));
+
+            // Ensure this transaction was created, and has three lines, and has some tax
+            Assert.NotNull(transaction, "Transaction should have been created");
+            Assert.True(transaction.totalTax > 0.0m, "Transaction should have had some tax");
+            Assert.True(transaction.lines.Count == 3, "Transaction should have three lines");
+            Assert.True(transaction.lines[2].ref1.Contains("Reference!"), "Line3 should have had a Ref1.");
+
+            // Now commit that transaction
+            var commitResult = Client.CommitTransaction(TestCompany.companyCode, transaction.code, null, null, new CommitTransactionModel() { commit = true });
+
+            // Ensure that this transaction was committed
+            Assert.NotNull(commitResult, "Should have been able to call CommitTransaction");
+            Assert.True(commitResult.status == DocumentStatus.Committed, "Transaction should have been committed");
+
+            // Now void the transaction
+            var voidResult = Client.VoidTransaction(TestCompany.companyCode, transaction.code, null, null, new VoidTransactionModel()
+            {
+                code = VoidReasonCode.DocVoided
+            });
+
+            // Ensure that the transaction was voided
+            Assert.NotNull(voidResult, "Should have been able to call VoidTransactoin");
+            Assert.True(voidResult.status == DocumentStatus.Cancelled, "Transaction should have been voided");
+        }
+
+        private AvaTaxCallEventArgs lastEvent = null;
+        private void Client_CallCompleted(object sender, EventArgs e)
+        {
+            lastEvent = e as AvaTaxCallEventArgs;
+        }
+
+        [Test]
+        
+        public void TaxOverrideExample()
+        {
+            // Create base transaction.
+            var builder = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice,
+                    "TaxOverrideCustomerCode")
+                .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
+                    "98104", "US")
+                .WithLine(100.0m, 1, "P0000000")
+                .WithLine(200m);
+
+            var transaction = builder.Create();
+
+            // Ensure this transaction was created.
+            Assert.NotNull(transaction, "Transaction should have been created");
+
+            // Add Line-level TaxOverride.
+            var overrideTransaction = builder
+                .WithLineTaxOverride(TaxOverrideType.TaxAmount, "Tax Override Reason", 1)
+                .Create();
+
+            // Ensure this transaction was created.
+            Assert.NotNull(overrideTransaction, "Transaction should have been created");
+
+            // Compare the two transactions.
+            Assert.AreEqual(overrideTransaction.totalTaxCalculated, transaction.totalTaxCalculated, "Total Tax Calculated should be the same.");
+            Assert.True(overrideTransaction.totalTax < transaction.totalTax, "Total Tax should not be the same. Overridden transaction should be smaller.");
+
+            // Compare the transaction lines.
+            var overrideLine = overrideTransaction.lines[1];
+            var line = transaction.lines[1];
+            Assert.AreEqual(overrideLine.isItemTaxable, line.isItemTaxable);
+            Assert.AreEqual(overrideLine.taxCalculated, line.taxCalculated);
+            Assert.AreEqual(overrideLine.lineAmount, line.lineAmount);
+            Assert.AreEqual(1, overrideLine.tax);
+            Assert.True(overrideLine.tax < line.tax);
+            Assert.AreEqual(TaxOverrideType.TaxAmount, overrideLine.taxOverrideType);
+        }
+    }
+}

--- a/tests/net6.0/NexusTests.cs
+++ b/tests/net6.0/NexusTests.cs
@@ -1,0 +1,169 @@
+﻿using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    [TestFixture]
+    [Ignore("This test is not yet implemented")]
+    public class NexusTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try {
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(typeof(TransactionTests).Name,
+                    typeof(TransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString().Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Greatest Popcorn",
+                    title = "Owner/CEO"
+                });
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex) {
+                Assert.Fail("Exception in SetUp: " + ex.ToString());
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try {
+
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex) {
+                Assert.Fail("Exception in TearDown: " + ex.ToString());
+            }
+        }
+        #endregion
+
+        [Test]
+        public void CreateAndDeleteNexus()
+        {
+            var nexusModels = new List<NexusModel>();
+
+            var stateNexus = new NexusModel
+            {
+                id = 0,
+                companyId = TestCompany.id,
+                country = "US",
+                region = "AL",
+                jurisTypeId = JurisTypeId.STA,
+                jurisCode = "01",
+                jurisName = "ALABAMA",
+                shortName = "AL",
+                signatureCode = "",
+                stateAssignedNo = "",
+                nexusTypeId = NexusTypeId.SalesOrSellersUseTax,
+                hasLocalNexus = true,
+                hasPermanentEstablishment = true,
+                effectiveDate = new DateTime(2008, 07, 01),
+                endDate = new DateTime(2019, 07, 01)
+            };
+
+            var cityNexus = new NexusModel
+            {
+                id = 0,
+                companyId = TestCompany.id,
+                country = "US",
+                region = "AL",
+                jurisTypeId = JurisTypeId.CIT,
+                jurisCode = "00124",
+                jurisName = "ABBEVILLE",
+                shortName = "ABBEVILLE",
+                signatureCode = "",
+                stateAssignedNo = "9356",
+                nexusTypeId = NexusTypeId.SalesTax,
+                hasLocalNexus = true,
+                hasPermanentEstablishment = false,
+                effectiveDate = new DateTime(2008, 07, 01),
+                endDate = new DateTime(2018, 07, 01)
+            };
+
+            nexusModels.Add(stateNexus);
+            nexusModels.Add(cityNexus);
+
+            var nexusModelsAdded = Client.CreateNexus(TestCompany.id, new List<NexusModel> { stateNexus, cityNexus });
+
+            // Get State nexus
+            NexusModel getALNexus = null;
+            try {
+                getALNexus = Client.GetNexus(TestCompany.id, nexusModelsAdded[0].id.Value, null);
+            } catch (Exception) { }
+            Assert.NotNull(getALNexus);
+
+            var fetchedUSNexus = new List<NexusModel> { getALNexus };
+
+            // Get City Nexus
+            NexusModel getCityNexus = null;
+            try {
+                getCityNexus = Client.GetNexus(TestCompany.id, nexusModelsAdded[1].id.Value, null);
+            } catch (Exception) { }
+            Assert.NotNull(getALNexus);
+
+            fetchedUSNexus.Add(getCityNexus);
+
+            // Delete Nexus
+            var errorResult = Client.DeleteNexus(TestCompany.id, nexusModelsAdded[1].id.Value, null);
+            Assert.NotNull(errorResult);
+        }
+    }
+}

--- a/tests/net6.0/SetUpFixture.cs
+++ b/tests/net6.0/SetUpFixture.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading.Tasks;
+using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    [SetUpFixture]
+    public class SetUpFixture
+    {
+        [OneTimeSetUp]
+        public void RunBeforeAnyTests()
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder
+                .AppendLine($"Hosting Framework Runtime Version: {GetRuntimeFrameworkVersion(GetType().Assembly)}")
+                .AppendLine($"Hosting Framework Version: {GetFrameworkVersion(GetType().Assembly)}")
+                .AppendLine($"Target Framework Runtime Version: {GetRuntimeFrameworkVersion(typeof(AvaTaxClient).Assembly)}")
+                .AppendLine($"Target Framework Version: {GetFrameworkVersion(typeof(AvaTaxClient).Assembly)}");
+
+            TestContext.Progress.WriteLine(stringBuilder);
+        }
+        
+        private static string GetRuntimeFrameworkVersion(Assembly assembly)
+        {
+            var imageRuntimeVersion = assembly
+                .ImageRuntimeVersion;
+
+            return imageRuntimeVersion;
+        }
+
+		private static string GetFrameworkVersion(Assembly assembly)  
+        {
+           var targetFrameAttribute = assembly.GetCustomAttributes(true)
+              .OfType<TargetFrameworkAttribute>().FirstOrDefault();
+           if (targetFrameAttribute == null)
+           {
+              return ".NET 2, 3 or 3.5";
+           }
+
+           return targetFrameAttribute.FrameworkName;
+       }
+    }
+}

--- a/tests/net6.0/TestBase.cs
+++ b/tests/net6.0/TestBase.cs
@@ -1,0 +1,103 @@
+﻿using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    public class TestBase
+    {
+        protected AvaTaxClient _client;
+        protected string _companyCode;
+        protected CompanyModel _testCompany;
+
+        [SetUp]
+        public void Setup()
+        {
+            _client = null;
+            _testCompany = null;
+            try
+            {
+                // Create a client and set up authentication
+                _client = new AvaTaxClient(GetType().Name,
+                    GetType().GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = _client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                _companyCode = Guid.NewGuid().ToString("N").Substring(0, 25);
+                // Create a basic company with nexus in the state of Washington
+                _testCompany = _client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = _companyCode,
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Hardware Store",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay after creating a company
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(_testCompany, "Test company should be created");
+                Assert.True(_testCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(_testCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                // Re-fetch the company
+                var company = _client.GetCompany(_testCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = _client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+    }
+}

--- a/tests/net6.0/TransactionTests.cs
+++ b/tests/net6.0/TransactionTests.cs
@@ -1,0 +1,211 @@
+﻿using Avalara.AvaTax.RestClient;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+
+namespace Avalara.AvaTax.RestClient.Test.net60
+{
+    [TestFixture]
+    public class TransactionTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try
+            {
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(typeof(TransactionTests).Name,
+                    typeof(TransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString().Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Greatest Popcorn",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// To debug this application, call app must be called with args[0] as username and args[1] as password
+        /// </summary>
+        [Test]
+        public void TransactionWorkflow()
+        {
+            Client.CallCompleted += Client_CallCompleted;
+            var tfn = System.IO.Path.GetTempFileName();
+            Client.LogToFile(tfn);
+
+            // Execute a transaction
+            var transaction = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice, "ABC")
+                .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
+                    "98104", "US")
+                .WithLine(100.0m, 1, "P0000000")
+                .WithLine(200m)
+                .WithExemptLine(50m, "NT")
+                .WithLineReference("Special Line Reference!", "Also this!")
+                .Create();
+
+            // Verify that the call was captured and logged
+            Assert.NotNull(lastEvent);
+            Assert.True(String.Equals(lastEvent.HttpVerb, "POST", StringComparison.CurrentCultureIgnoreCase));
+            Assert.True(String.Equals(lastEvent.RequestUri.ToString(), "https://sandbox-rest.avatax.com/api/v2/transactions/create", StringComparison.CurrentCultureIgnoreCase));
+            Assert.AreEqual(lastEvent.Code, HttpStatusCode.Created);
+
+            // Verify that the log file was created
+            Assert.True(System.IO.File.Exists(tfn));
+
+            // Ensure this transaction was created, and has three lines, and has some tax
+            Assert.NotNull(transaction, "Transaction should have been created");
+            Assert.True(transaction.totalTax > 0.0m, "Transaction should have had some tax");
+            Assert.True(transaction.lines.Count == 3, "Transaction should have three lines");
+            Assert.True(transaction.lines[2].ref1.Contains("Reference!"), "Line3 should have had a Ref1.");
+
+            // Now commit that transaction
+            var commitResult = Client.CommitTransaction(TestCompany.companyCode, transaction.code, null, null, new CommitTransactionModel() { commit = true });
+
+            // Ensure that this transaction was committed
+            Assert.NotNull(commitResult, "Should have been able to call CommitTransaction");
+            Assert.True(commitResult.status == DocumentStatus.Committed, "Transaction should have been committed");
+
+            // Now void the transaction
+            var voidResult = Client.VoidTransaction(TestCompany.companyCode, transaction.code, null, null, new VoidTransactionModel()
+            {
+                code = VoidReasonCode.DocVoided
+            });
+
+            // Ensure that the transaction was voided
+            Assert.NotNull(voidResult, "Should have been able to call VoidTransactoin");
+            Assert.True(voidResult.status == DocumentStatus.Cancelled, "Transaction should have been voided");
+        }
+
+        private AvaTaxCallEventArgs lastEvent = null;
+        private void Client_CallCompleted(object sender, EventArgs e)
+        {
+            lastEvent = e as AvaTaxCallEventArgs;
+        }
+        [Ignore("Ignore Override")]
+        [Test]
+        public void TaxOverrideExample()
+        {
+            // Create base transaction.
+            var builder = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice,
+                    "TaxOverrideCustomerCode")
+                .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
+                    "98104", "US")
+                .WithLine(100.0m, 1, "P0000000")
+                .WithLine(200m);
+
+            var transaction = builder.Create();
+
+            // Ensure this transaction was created.
+            Assert.NotNull(transaction, "Transaction should have been created");
+
+            var taxOverrideList = new List<TransactionLineTaxAmountByTaxTypeModel>();
+            var item = new TransactionLineTaxAmountByTaxTypeModel();
+            item.taxTypeId = "123";
+            item.taxAmount = 10;
+            taxOverrideList.Add(item);
+            // Add Line-level TaxOverride.
+            var overrideTransaction = builder
+                .WithLineTaxOverride(TaxOverrideType.TaxAmount, "Tax Override Reason", 1)
+                .WithLine(300m, 1)
+                .WithLineTaxOverride(TaxOverrideType.TaxAmountByTaxType, "Another reason", 10, null, taxOverrideList)
+                .Create();
+
+
+            // Ensure this transaction was created.
+            Assert.NotNull(overrideTransaction, "Transaction should have been created");
+
+            // Compare the two transactions.
+            Assert.AreEqual(overrideTransaction.totalTaxCalculated, transaction.totalTaxCalculated, "Total Tax Calculated should be the same.");
+            Assert.True(overrideTransaction.totalTax < transaction.totalTax, "Total Tax should not be the same. Overridden transaction should be smaller.");
+
+            // Compare the transaction lines.
+            var overrideLine = overrideTransaction.lines[1];
+            var line = transaction.lines[1];
+            Assert.AreEqual(overrideLine.isItemTaxable, line.isItemTaxable);
+            Assert.AreEqual(overrideLine.taxCalculated, line.taxCalculated);
+            Assert.AreEqual(overrideLine.lineAmount, line.lineAmount);
+            Assert.AreEqual(1, overrideLine.tax);
+            Assert.True(overrideLine.tax < line.tax);
+            Assert.AreEqual(TaxOverrideType.TaxAmount, overrideLine.taxOverrideType);
+        }
+    }
+}

--- a/tests/net8.0/BatchTests.cs
+++ b/tests/net8.0/BatchTests.cs
@@ -1,0 +1,198 @@
+﻿using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    [TestFixture]
+    public class BatchTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try
+            {
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(typeof(TransactionTests).Name,
+                    typeof(TransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString("N").Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Hardware Store",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay after creating a company
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Test]
+        public async Task BatchesWorkflow()
+        {
+            // Raw batch CSV string.
+            const string transactionImport = @"ProcessCode,DocCode,DocType,DocDate,CompanyCode,CustomerCode,EntityUseCode,LineNo,TaxCode,TaxDate,ItemCode,Description,Qty,Amount,Discount,Ref1,Ref2,ExemptionNo,RevAcct,DestAddress,DestCity,DestRegion,DestPostalCode,DestCountry,OrigAddress,OrigCity,OrigRegion,OrigPostalCode,OrigCountry,LocationCode,SalesPersonCode,PurchaseOrderNo,CurrencyCode,ExchangeRate,ExchangeRateEffDate,PaymentDate,TaxIncluded,DestTaxRegion,OrigTaxRegion,Taxable,TaxType,TotalTax,CountryName,CountryCode,CountryRate,CountryTax,StateName,StateCode,StateRate,StateTax,CountyName,CountyCode,CountyRate,CountyTax,CityName,CityCode,CityRate,CityTax,Other1Name,Other1Code,Other1Rate,Other1Tax,Other2Name,Other2Code,Other2Rate,Other2Tax,Other3Name,Other3Code,Other3Rate,Other3Tax,Other4Name,Other4Code,Other4Rate,Other4Tax,ReferenceCode,BuyersVATNo
+3,BS1323154187029MG10,2,16-Apr-14,,029MG10,,0000000001,SR060100,06-May-14,6500,REPAIRS & MAINTENANCE,,1980,,,0,,6500,119 N. 72nd St.,Omaha,NE,68114,,6923 MAPLE ST,OMAHA,NE,68104,,029,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS1323158772194036MAC1,2,04-Apr-14,,036MAC1,,0000000001,SC150158,06-May-14,6505,R&M HEAT / VENT / AIR COND,,322.26,,,0,,6505,1200 E. Mall Drive,Holland,OH,43528,,2875 CRANE WAY,NORTHWOOD,OH,43619,,036,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS1323159W206409036MLK,2,25-Mar-14,,036MLK,,0000000001,SR060100,06-May-14,6507,R&M OTHER,,449,,,31.43,,6507,1200 E. Mall Drive,Holland,OH,43528,,1214 JEFFERSON AVE,TOLEDO,OH,43604,,036,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231601596048MRP2,2,02-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,60,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231631591048MRP2,2,02-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,58,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231611594048MRP2,2,01-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,65,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231621593048MRP2,2,01-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,75,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231641587048MRP2,2,01-May-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,60,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+3,BS13231651582048MRP2,2,15-Mar-14,,048MRP2,,0000000001,SR060100,06-May-14,6520,FURNITURE REPAIRS,,47,,,0,,6520,2201 Hwy 75 North,Sherman,TX,75090,,P.O. BOX 125,POTTSBORO,TX,75076,,048,,,USD,,,,0,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,";
+
+            // Let's Create the file portion of the batch request.
+            var batchFileModel = new BatchFileModel
+            {
+                name = "TransactionImport.csv",
+                content = Encoding.UTF8.GetBytes(transactionImport),
+                contentType = "text/csv",
+                fileExtension = "csv"
+            };
+
+            // Create the bare-minimum batch header info.
+            var batchRequest = new BatchModel
+            {
+                name = "AutomationTestBatch",
+                type = BatchType.TransactionImport,
+                files = new List<BatchFileModel> { batchFileModel }
+            };
+
+            // Send the batch!
+            try
+            {
+                var batchResult = Client.CreateBatches(TestCompany.id, new List<BatchModel> { batchRequest });
+                Assert.NotNull(batchResult, "Batch not sent.");
+                Assert.True(batchResult.Count > 0, "No batches created.");
+
+                // Check that the batch comes out of Waiting state using a linear backoff strategy.
+                var waiting = true;
+                BatchModel batchFetchResult = null;
+                for (var i = 1; i < 6; ++i)
+                {
+                    await Task.Delay(i * 1000);
+
+                    batchFetchResult = Client.GetBatch(TestCompany.id, batchResult[0].id.Value);
+                    Assert.NotNull(batchFetchResult, "Batch fetch unsuccessful.");
+                    if (batchFetchResult.status.Value == BatchStatus.Waiting) continue;
+                    waiting = false;
+                    break;
+                }
+                Assert.True(waiting == false, $"Batch waiting too long. Check BatchId: {batchResult[0].id}");
+
+                // This batch is no longer in the Waiting state. Let's see it process.
+                var processing = true;
+                for (var i = 1; i < 11; ++i)
+                {
+                    await Task.Delay(i * 1000);
+
+                    batchFetchResult = Client.GetBatch(TestCompany.id, batchResult[0].id.Value);
+                    Assert.NotNull(batchFetchResult, "Batch fetch unsuccessful.");
+                    if (batchFetchResult.status.Value == BatchStatus.Processing) continue;
+                    processing = false;
+                    break;
+                }
+                Assert.True(processing == false, $"Batch processing too long. Check BatchId: {batchResult[0].id}");
+
+                // This batch is done processing. 
+                Assert.True((batchFetchResult.status.Value == BatchStatus.Errors || batchFetchResult.status.Value == BatchStatus.Completed),
+                    $"BatchId: {batchResult[0].id} should either complete or error out.");
+                // Ensure that the number of records matches what we sent in.
+                Assert.AreEqual(9, batchFetchResult.currentRecord.Value);
+
+                // Alright. Time to download the sent batch file.
+                var fileResult = Client.DownloadBatch(TestCompany.id, batchFetchResult.id.Value, batchFetchResult.files[0].id.Value);
+                Assert.NotNull(fileResult);
+
+                // Compare what we got back with what we sent.
+                Assert.AreEqual(batchFetchResult.name + ".Input.CSV; filename*=UTF-8''" + batchFetchResult.name + ".Input.CSV", fileResult.Filename);
+                Assert.AreEqual(batchFileModel.content, fileResult.Data);
+                Assert.AreEqual(batchFileModel.contentType, fileResult.ContentType);
+            } catch (AvaTaxError e)
+            {
+                Assert.True(false, $"AvaTaxError: {e.error.error.details?[0].message}");
+            } catch (Exception e)
+            {
+                Assert.True(false, $"Unknown Exception! {e.Message}");
+            }
+        }
+    }
+}

--- a/tests/net8.0/CertificateTests.cs
+++ b/tests/net8.0/CertificateTests.cs
@@ -1,0 +1,144 @@
+﻿using Avalara.AvaTax.RestClient;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Net;
+using System.Reflection;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    [TestFixture]
+    public class CertificateTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public int DefaultCompanyId { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try {
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(typeof(CertificateTests).Name,
+                    typeof(CertificateTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                //Get the default company.
+                var defaultCompanyModel = Client.QueryCompanies(string.Empty, "isDefault EQ true", null, null, string.Empty).value[0];
+
+                DefaultCompanyId = defaultCompanyModel.id;
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString().Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Greatest Popcorn",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex) {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try {
+
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex) {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// Tests the upload certificate image endpoint.
+        /// </summary>
+        [Test]
+        [Ignore("Ignore CertificateImageUploadTest")]
+        public void CertificateImageUploadTest()
+        {
+            //Get the cert number. The account needs to have CertCapture 
+            //be provisioned, already have a certificate created, and the
+            //certificate needs to be valid.
+            var certs = Client.QueryCertificates(DefaultCompanyId, string.Empty, "valid EQ true", null, null, string.Empty).value;
+            var certId = certs[0].id.Value;
+
+            //Get an image.
+            byte[] jpegByteArr = File.ReadAllBytes(Environment.GetEnvironmentVariable("TEST_IMAGE_PATH"));
+
+            FileResult fileResult = new FileResult()
+            {
+                ContentType = "multipart/form-data",
+                Filename = "test_cert_image.jpg",
+                Data = jpegByteArr
+            };
+
+            //Send request.
+            var certUploadResult = Client.UploadCertificateImage(DefaultCompanyId, certId, fileResult);
+
+            //Response should be "OK"
+            Assert.True(string.Equals(certUploadResult, "\"OK\""));
+
+            //Test download of image attachment.
+            var certAttachment = Client.DownloadCertificateImage(DefaultCompanyId, certId, null, CertificatePreviewType.Pdf);
+            Assert.NotNull(certAttachment);
+            Assert.True(string.Equals(certAttachment.ContentType, "application/pdf"));
+            Assert.True(certAttachment.Data.Length > 1000);
+            
+        }
+    }
+}

--- a/tests/net8.0/ErrorResultTests.cs
+++ b/tests/net8.0/ErrorResultTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    [TestFixture]
+    public class ErrorResultTests : TestBase
+    {
+        [Test]
+        public async Task NonJsonErrorResult()
+        {
+            AvaTaxError avataxError = null;
+            try
+            {
+                // make a client that points to a server that will give a 404 for ping
+                var client = new AvaTaxClient(GetType().Name,
+                        GetType().GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                        Environment.MachineName, new Uri("https://www.google.com"));
+
+                var result = await client.PingAsync().ConfigureAwait(false);
+            }
+            catch (AvaTaxError e)
+            {
+                avataxError = e;
+            }
+
+            Assert.NotNull(avataxError);
+            Assert.True(avataxError.error.error.message.Contains("the response is in an unexpected format"));
+            Assert.True(avataxError.error.error.details[0].description.ToLower().Contains("not found"));
+        }
+
+        [Test]
+        public async Task JsonErrorResult()
+        {
+            AvaTaxError avataxError = null;
+            try
+            {
+                var result = await _client.ChangePasswordAsync(new PasswordChangeModel
+                {
+                }).ConfigureAwait(false);
+            }
+            catch (AvaTaxError e)
+            {
+                avataxError = e;
+            }
+
+            Assert.NotNull(avataxError);
+            Assert.True(avataxError.error.error.message.Contains("Field oldPassword is required"));
+        }
+    }
+}

--- a/tests/net8.0/FreeTaxRatesTest.cs
+++ b/tests/net8.0/FreeTaxRatesTest.cs
@@ -1,0 +1,97 @@
+﻿using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    [TestFixture]
+    class FreeTaxRatesTest
+    {
+        public AvaTaxClient _client;
+
+        #region Setup / Teardown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try {
+                // Create a client and set up authentication
+                _client = new AvaTaxClient(typeof(TransactionTests).Name,
+                typeof(TransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                Environment.MachineName,
+                AvaTaxEnvironment.Sandbox)
+                .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+            } catch (Exception ex) {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+        #endregion
+
+        [Test]
+        public async Task FreeTaxRates()
+        {
+            // Call TaxRates for a few addresses and verify that the rates are nonzero
+            var tr = await _client.TaxRatesByAddressAsync("123 Main Street", null, null, "Irvine", "CA", "92615", "US");
+            Assert.NotNull(tr);
+            Assert.True(tr.totalRate > 0.05m);
+
+            // Washington
+            tr = await _client.TaxRatesByAddressAsync("522 Stadium Pl S", null, null, "Seattle", "WA", "98104", "US");
+            Assert.NotNull(tr);
+            Assert.True(tr.totalRate > 0.05m);
+
+            // By postal code for New York
+            tr = await _client.TaxRatesByPostalCodeAsync("US", "10010");
+            Assert.NotNull(tr);
+            Assert.True(tr.totalRate > 0.05m);
+        }
+
+        /// <summary>
+        /// Test the local rate by ZIP storage and retrieval.
+        /// </summary>        
+        [Test]
+        [Ignore("This test will fail in Travis")]
+        public void StoreRatesByZipTest()
+        {
+            string path = Environment.GetEnvironmentVariable("ZIP_RATE_FILE_STORAGE_PATH");
+            List<string> zips = new List<string>() { "12590", "98104" };
+
+            //Call the content caching helper.
+            AvaTaxOfflineHelper.StoreZipRateContent(_client, "US", zips, path);
+
+            //Verify that the files were stored locally. 
+            bool zipRateExists = AvaTaxOfflineHelper.VerifyLocalZipRateAvailable(zips[0], path);
+            Assert.True(zipRateExists);
+            zipRateExists = AvaTaxOfflineHelper.VerifyLocalZipRateAvailable(zips[1], path);
+            Assert.True(zipRateExists);
+
+            //Verify that a bogus file does not exist locally.
+            zipRateExists = AvaTaxOfflineHelper.VerifyLocalZipRateAvailable("bogusZipFile.json", path);
+            Assert.False(zipRateExists);
+
+            //Verify that the local file can be used for rate calculation.
+            var zipTaxRate = AvaTaxOfflineHelper.GetLocalTaxRateByZip(zips[1], path);
+            Assert.NotNull(zipTaxRate);
+            decimal result = 9.99m * zipTaxRate.totalRate.Value;
+            Assert.NotZero(result);
+
+            //Test AvaTaxOfflineHelper Exception handling.
+            path = @"n:\someBadPath";
+            try {
+                AvaTaxOfflineHelper.StoreZipRateContent(_client, "US", zips, path);
+            } catch (AvaTaxOfflineHelperException exc) {
+#if PORTABLE
+                Assert.True(string.Equals(exc.InnerException.Message, "Could not find a part of the path 'n:\\someBadPath\\12590.json'."));
+#else
+                Assert.True(string.Equals(exc.Message, "An error occurred retrieving or storing the rate content. Please see inner exception for details."));
+#endif
+            }
+        }
+    }
+}

--- a/tests/net8.0/HttpClientTransactionTests.cs
+++ b/tests/net8.0/HttpClientTransactionTests.cs
@@ -1,0 +1,204 @@
+﻿using Avalara.AvaTax.RestClient;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Reflection;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    [TestFixture]
+    public class HttpClientTransactionTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try
+            {
+                var httpClient = new System.Net.Http.HttpClient() { Timeout = TimeSpan.FromMinutes(20) };
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(httpClient, typeof(HttpClientTransactionTests).Name,
+                    typeof(HttpClientTransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString().Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Greatest Popcorn",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// To debug this application, call app must be called with args[0] as username and args[1] as password
+        /// </summary>
+        [Test]
+		public void TransactionWorkflow()
+        {
+            Client.CallCompleted += Client_CallCompleted;
+            var tfn = System.IO.Path.GetTempFileName();
+            Client.LogToFile(tfn);
+
+            // Execute a transaction
+            var transaction = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice, "ABC")
+                .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
+                    "98104", "US")
+                .WithLine(100.0m, 1, "P0000000")
+                .WithLine(200m)
+                .WithExemptLine(50m, "NT")
+                .WithLineReference("Special Line Reference!", "Also this!")
+                .Create();
+
+            // Verify that the call was captured and logged
+            Assert.NotNull(lastEvent);
+            Assert.True(String.Equals(lastEvent.HttpVerb, "POST", StringComparison.CurrentCultureIgnoreCase));
+            Assert.True(String.Equals(lastEvent.RequestUri.ToString(), "https://sandbox-rest.avatax.com/api/v2/transactions/create", StringComparison.CurrentCultureIgnoreCase));
+            Assert.AreEqual(lastEvent.Code, HttpStatusCode.Created);
+
+            // Verify that the log file was created
+            Assert.True(System.IO.File.Exists(tfn));
+
+            // Ensure this transaction was created, and has three lines, and has some tax
+            Assert.NotNull(transaction, "Transaction should have been created");
+            Assert.True(transaction.totalTax > 0.0m, "Transaction should have had some tax");
+            Assert.True(transaction.lines.Count == 3, "Transaction should have three lines");
+            Assert.True(transaction.lines[2].ref1.Contains("Reference!"), "Line3 should have had a Ref1.");
+
+            // Now commit that transaction
+            var commitResult = Client.CommitTransaction(TestCompany.companyCode, transaction.code, null, null, new CommitTransactionModel() { commit = true });
+
+            // Ensure that this transaction was committed
+            Assert.NotNull(commitResult, "Should have been able to call CommitTransaction");
+            Assert.True(commitResult.status == DocumentStatus.Committed, "Transaction should have been committed");
+
+            // Now void the transaction
+            var voidResult = Client.VoidTransaction(TestCompany.companyCode, transaction.code, null, null, new VoidTransactionModel()
+            {
+                code = VoidReasonCode.DocVoided
+            });
+
+            // Ensure that the transaction was voided
+            Assert.NotNull(voidResult, "Should have been able to call VoidTransactoin");
+            Assert.True(voidResult.status == DocumentStatus.Cancelled, "Transaction should have been voided");
+        }
+
+        private AvaTaxCallEventArgs lastEvent = null;
+        private void Client_CallCompleted(object sender, EventArgs e)
+        {
+            lastEvent = e as AvaTaxCallEventArgs;
+        }
+
+        [Test]
+        
+        public void TaxOverrideExample()
+        {
+            // Create base transaction.
+            var builder = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice,
+                    "TaxOverrideCustomerCode")
+                .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
+                    "98104", "US")
+                .WithLine(100.0m, 1, "P0000000")
+                .WithLine(200m);
+
+            var transaction = builder.Create();
+
+            // Ensure this transaction was created.
+            Assert.NotNull(transaction, "Transaction should have been created");
+
+            // Add Line-level TaxOverride.
+            var overrideTransaction = builder
+                .WithLineTaxOverride(TaxOverrideType.TaxAmount, "Tax Override Reason", 1)
+                .Create();
+
+            // Ensure this transaction was created.
+            Assert.NotNull(overrideTransaction, "Transaction should have been created");
+
+            // Compare the two transactions.
+            Assert.AreEqual(overrideTransaction.totalTaxCalculated, transaction.totalTaxCalculated, "Total Tax Calculated should be the same.");
+            Assert.True(overrideTransaction.totalTax < transaction.totalTax, "Total Tax should not be the same. Overridden transaction should be smaller.");
+
+            // Compare the transaction lines.
+            var overrideLine = overrideTransaction.lines[1];
+            var line = transaction.lines[1];
+            Assert.AreEqual(overrideLine.isItemTaxable, line.isItemTaxable);
+            Assert.AreEqual(overrideLine.taxCalculated, line.taxCalculated);
+            Assert.AreEqual(overrideLine.lineAmount, line.lineAmount);
+            Assert.AreEqual(1, overrideLine.tax);
+            Assert.True(overrideLine.tax < line.tax);
+            Assert.AreEqual(TaxOverrideType.TaxAmount, overrideLine.taxOverrideType);
+        }
+    }
+}

--- a/tests/net8.0/NexusTests.cs
+++ b/tests/net8.0/NexusTests.cs
@@ -1,0 +1,169 @@
+﻿using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    [TestFixture]
+    [Ignore("This test is not yet implemented")]
+    public class NexusTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try {
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(typeof(TransactionTests).Name,
+                    typeof(TransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString().Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Greatest Popcorn",
+                    title = "Owner/CEO"
+                });
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex) {
+                Assert.Fail("Exception in SetUp: " + ex.ToString());
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try {
+
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex) {
+                Assert.Fail("Exception in TearDown: " + ex.ToString());
+            }
+        }
+        #endregion
+
+        [Test]
+        public void CreateAndDeleteNexus()
+        {
+            var nexusModels = new List<NexusModel>();
+
+            var stateNexus = new NexusModel
+            {
+                id = 0,
+                companyId = TestCompany.id,
+                country = "US",
+                region = "AL",
+                jurisTypeId = JurisTypeId.STA,
+                jurisCode = "01",
+                jurisName = "ALABAMA",
+                shortName = "AL",
+                signatureCode = "",
+                stateAssignedNo = "",
+                nexusTypeId = NexusTypeId.SalesOrSellersUseTax,
+                hasLocalNexus = true,
+                hasPermanentEstablishment = true,
+                effectiveDate = new DateTime(2008, 07, 01),
+                endDate = new DateTime(2019, 07, 01)
+            };
+
+            var cityNexus = new NexusModel
+            {
+                id = 0,
+                companyId = TestCompany.id,
+                country = "US",
+                region = "AL",
+                jurisTypeId = JurisTypeId.CIT,
+                jurisCode = "00124",
+                jurisName = "ABBEVILLE",
+                shortName = "ABBEVILLE",
+                signatureCode = "",
+                stateAssignedNo = "9356",
+                nexusTypeId = NexusTypeId.SalesTax,
+                hasLocalNexus = true,
+                hasPermanentEstablishment = false,
+                effectiveDate = new DateTime(2008, 07, 01),
+                endDate = new DateTime(2018, 07, 01)
+            };
+
+            nexusModels.Add(stateNexus);
+            nexusModels.Add(cityNexus);
+
+            var nexusModelsAdded = Client.CreateNexus(TestCompany.id, new List<NexusModel> { stateNexus, cityNexus });
+
+            // Get State nexus
+            NexusModel getALNexus = null;
+            try {
+                getALNexus = Client.GetNexus(TestCompany.id, nexusModelsAdded[0].id.Value, null);
+            } catch (Exception) { }
+            Assert.NotNull(getALNexus);
+
+            var fetchedUSNexus = new List<NexusModel> { getALNexus };
+
+            // Get City Nexus
+            NexusModel getCityNexus = null;
+            try {
+                getCityNexus = Client.GetNexus(TestCompany.id, nexusModelsAdded[1].id.Value, null);
+            } catch (Exception) { }
+            Assert.NotNull(getALNexus);
+
+            fetchedUSNexus.Add(getCityNexus);
+
+            // Delete Nexus
+            var errorResult = Client.DeleteNexus(TestCompany.id, nexusModelsAdded[1].id.Value, null);
+            Assert.NotNull(errorResult);
+        }
+    }
+}

--- a/tests/net8.0/SetUpFixture.cs
+++ b/tests/net8.0/SetUpFixture.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading.Tasks;
+using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    [SetUpFixture]
+    public class SetUpFixture
+    {
+        [OneTimeSetUp]
+        public void RunBeforeAnyTests()
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder
+                .AppendLine($"Hosting Framework Runtime Version: {GetRuntimeFrameworkVersion(GetType().Assembly)}")
+                .AppendLine($"Hosting Framework Version: {GetFrameworkVersion(GetType().Assembly)}")
+                .AppendLine($"Target Framework Runtime Version: {GetRuntimeFrameworkVersion(typeof(AvaTaxClient).Assembly)}")
+                .AppendLine($"Target Framework Version: {GetFrameworkVersion(typeof(AvaTaxClient).Assembly)}");
+
+            TestContext.Progress.WriteLine(stringBuilder);
+        }
+        
+        private static string GetRuntimeFrameworkVersion(Assembly assembly)
+        {
+            var imageRuntimeVersion = assembly
+                .ImageRuntimeVersion;
+
+            return imageRuntimeVersion;
+        }
+
+		private static string GetFrameworkVersion(Assembly assembly)  
+        {
+           var targetFrameAttribute = assembly.GetCustomAttributes(true)
+              .OfType<TargetFrameworkAttribute>().FirstOrDefault();
+           if (targetFrameAttribute == null)
+           {
+              return ".NET 2, 3 or 3.5";
+           }
+
+           return targetFrameAttribute.FrameworkName;
+       }
+    }
+}

--- a/tests/net8.0/TestBase.cs
+++ b/tests/net8.0/TestBase.cs
@@ -1,0 +1,103 @@
+﻿using Avalara.AvaTax.RestClient;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    public class TestBase
+    {
+        protected AvaTaxClient _client;
+        protected string _companyCode;
+        protected CompanyModel _testCompany;
+
+        [SetUp]
+        public void Setup()
+        {
+            _client = null;
+            _testCompany = null;
+            try
+            {
+                // Create a client and set up authentication
+                _client = new AvaTaxClient(GetType().Name,
+                    GetType().GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = _client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                _companyCode = Guid.NewGuid().ToString("N").Substring(0, 25);
+                // Create a basic company with nexus in the state of Washington
+                _testCompany = _client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = _companyCode,
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Hardware Store",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay after creating a company
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(_testCompany, "Test company should be created");
+                Assert.True(_testCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(_testCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                // Re-fetch the company
+                var company = _client.GetCompany(_testCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = _client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+    }
+}

--- a/tests/net8.0/TransactionTests.cs
+++ b/tests/net8.0/TransactionTests.cs
@@ -1,0 +1,211 @@
+﻿using Avalara.AvaTax.RestClient;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+
+namespace Avalara.AvaTax.RestClient.Test.net80
+{
+    [TestFixture]
+    public class TransactionTests
+    {
+        public AvaTaxClient Client { get; set; }
+        public string CompanyCode { get; set; }
+        public CompanyModel TestCompany { get; set; }
+
+        #region Setup / TearDown
+        /// <summary>
+        /// Create a company for use with these tests
+        /// </summary>
+        [SetUp]
+        public void Setup()
+        {
+            try
+            {
+                // Create a client and set up authentication
+                Client = new AvaTaxClient(typeof(TransactionTests).Name,
+                    typeof(TransactionTests).GetTypeInfo().Assembly.ImageRuntimeVersion.ToString(),
+                    Environment.MachineName,
+                    AvaTaxEnvironment.Sandbox)
+                    .WithSecurity(Environment.GetEnvironmentVariable("SANDBOX_USERNAME"), Environment.GetEnvironmentVariable("SANDBOX_PASSWORD"));
+
+                // Verify that we can ping successfully
+                var pingResult = Client.Ping();
+
+                // Assert that ping succeeded
+                Assert.NotNull(pingResult, "Should be able to call Ping");
+                Assert.True(pingResult.authenticated, "Environment variables should provide correct authentication");
+
+                // Create a basic company with nexus in the state of Washington
+                TestCompany = Client.CompanyInitialize(new CompanyInitializationModel()
+                {
+                    city = "Bainbridge Island",
+                    companyCode = Guid.NewGuid().ToString().Substring(0, 25),
+                    country = "US",
+                    email = "bob@example.org",
+                    faxNumber = null,
+                    firstName = "Bob",
+                    lastName = "McExample",
+                    line1 = "100 Ravine Lane",
+                    mobileNumber = "206 555 1212",
+                    phoneNumber = "206 555 1212",
+                    postalCode = "98110",
+                    region = "WA",
+                    taxpayerIdNumber = "123456789",
+                    name = "Bob's Greatest Popcorn",
+                    title = "Owner/CEO"
+                });
+
+                // Add a delay
+                System.Threading.Thread.Sleep(6 * 1000);
+
+                // Assert that company setup succeeded
+                Assert.NotNull(TestCompany, "Test company should be created");
+                Assert.True(TestCompany.nexus.Count > 0, "Test company should have nexus");
+                Assert.True(TestCompany.locations.Count > 0, "Test company should have locations");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in SetUp: " + ex);
+            }
+        }
+
+
+        /// <summary>
+        /// Any cleanup required goes here
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+
+                // Re-fetch the company
+                var company = Client.GetCompany(TestCompany.id, null);
+
+                // Flag this company as inactive
+                company.isActive = false;
+                var disableResult = Client.UpdateCompany(company.id, company);
+
+                // Assert that it succeeded
+                Assert.NotNull(disableResult, "Should have been able to update this company");
+                Assert.False(disableResult.isActive, "Company should have been deactivated");
+
+                // Shouldn't fail
+            } catch (Exception ex)
+            {
+                Assert.Fail("Exception in TearDown: " + ex);
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// To debug this application, call app must be called with args[0] as username and args[1] as password
+        /// </summary>
+        [Test]
+        public void TransactionWorkflow()
+        {
+            Client.CallCompleted += Client_CallCompleted;
+            var tfn = System.IO.Path.GetTempFileName();
+            Client.LogToFile(tfn);
+
+            // Execute a transaction
+            var transaction = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice, "ABC")
+                .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
+                    "98104", "US")
+                .WithLine(100.0m, 1, "P0000000")
+                .WithLine(200m)
+                .WithExemptLine(50m, "NT")
+                .WithLineReference("Special Line Reference!", "Also this!")
+                .Create();
+
+            // Verify that the call was captured and logged
+            Assert.NotNull(lastEvent);
+            Assert.True(String.Equals(lastEvent.HttpVerb, "POST", StringComparison.CurrentCultureIgnoreCase));
+            Assert.True(String.Equals(lastEvent.RequestUri.ToString(), "https://sandbox-rest.avatax.com/api/v2/transactions/create", StringComparison.CurrentCultureIgnoreCase));
+            Assert.AreEqual(lastEvent.Code, HttpStatusCode.Created);
+
+            // Verify that the log file was created
+            Assert.True(System.IO.File.Exists(tfn));
+
+            // Ensure this transaction was created, and has three lines, and has some tax
+            Assert.NotNull(transaction, "Transaction should have been created");
+            Assert.True(transaction.totalTax > 0.0m, "Transaction should have had some tax");
+            Assert.True(transaction.lines.Count == 3, "Transaction should have three lines");
+            Assert.True(transaction.lines[2].ref1.Contains("Reference!"), "Line3 should have had a Ref1.");
+
+            // Now commit that transaction
+            var commitResult = Client.CommitTransaction(TestCompany.companyCode, transaction.code, null, null, new CommitTransactionModel() { commit = true });
+
+            // Ensure that this transaction was committed
+            Assert.NotNull(commitResult, "Should have been able to call CommitTransaction");
+            Assert.True(commitResult.status == DocumentStatus.Committed, "Transaction should have been committed");
+
+            // Now void the transaction
+            var voidResult = Client.VoidTransaction(TestCompany.companyCode, transaction.code, null, null, new VoidTransactionModel()
+            {
+                code = VoidReasonCode.DocVoided
+            });
+
+            // Ensure that the transaction was voided
+            Assert.NotNull(voidResult, "Should have been able to call VoidTransactoin");
+            Assert.True(voidResult.status == DocumentStatus.Cancelled, "Transaction should have been voided");
+        }
+
+        private AvaTaxCallEventArgs lastEvent = null;
+        private void Client_CallCompleted(object sender, EventArgs e)
+        {
+            lastEvent = e as AvaTaxCallEventArgs;
+        }
+        [Ignore("Ignore Override")]
+        [Test]
+        public void TaxOverrideExample()
+        {
+            // Create base transaction.
+            var builder = new TransactionBuilder(Client, TestCompany.companyCode, DocumentType.SalesInvoice,
+                    "TaxOverrideCustomerCode")
+                .WithAddress(TransactionAddressType.SingleLocation, "521 S Weller St", null, null, "Seattle", "WA",
+                    "98104", "US")
+                .WithLine(100.0m, 1, "P0000000")
+                .WithLine(200m);
+
+            var transaction = builder.Create();
+
+            // Ensure this transaction was created.
+            Assert.NotNull(transaction, "Transaction should have been created");
+
+            var taxOverrideList = new List<TransactionLineTaxAmountByTaxTypeModel>();
+            var item = new TransactionLineTaxAmountByTaxTypeModel();
+            item.taxTypeId = "123";
+            item.taxAmount = 10;
+            taxOverrideList.Add(item);
+            // Add Line-level TaxOverride.
+            var overrideTransaction = builder
+                .WithLineTaxOverride(TaxOverrideType.TaxAmount, "Tax Override Reason", 1)
+                .WithLine(300m, 1)
+                .WithLineTaxOverride(TaxOverrideType.TaxAmountByTaxType, "Another reason", 10, null, taxOverrideList)
+                .Create();
+
+
+            // Ensure this transaction was created.
+            Assert.NotNull(overrideTransaction, "Transaction should have been created");
+
+            // Compare the two transactions.
+            Assert.AreEqual(overrideTransaction.totalTaxCalculated, transaction.totalTaxCalculated, "Total Tax Calculated should be the same.");
+            Assert.True(overrideTransaction.totalTax < transaction.totalTax, "Total Tax should not be the same. Overridden transaction should be smaller.");
+
+            // Compare the transaction lines.
+            var overrideLine = overrideTransaction.lines[1];
+            var line = transaction.lines[1];
+            Assert.AreEqual(overrideLine.isItemTaxable, line.isItemTaxable);
+            Assert.AreEqual(overrideLine.taxCalculated, line.taxCalculated);
+            Assert.AreEqual(overrideLine.lineAmount, line.lineAmount);
+            Assert.AreEqual(1, overrideLine.tax);
+            Assert.True(overrideLine.tax < line.tax);
+            Assert.AreEqual(TaxOverrideType.TaxAmount, overrideLine.taxOverrideType);
+        }
+    }
+}


### PR DESCRIPTION
This MR explicitly adds .NET 6 and .NET 8 as targets for the SDK

- Add support for .NET 6 and .NET 8 as targeting packs in project files
- Add solution file that references the project files
- Add tests for .NET 6 and .NET 8 _(same as ,NET Standard 2.0 tests)_
- Change the way a directory's control is set based [off the documentation here](https://learn.microsoft.com/en-us/dotnet/api/system.io.directoryinfo?view=net-8.0#methods)
- Clean up, organize, and simplify the project files