### PR TITLE
Add a WithLineAddress Override Allowing Geo Location

### DIFF
--- a/src/TransactionBuilder.cs
+++ b/src/TransactionBuilder.cs
@@ -293,6 +293,41 @@ namespace Avalara.AvaTax.RestClient
             return this;
         }
 
+
+        /// <summary>
+        /// Add an address to this line with lat/long
+        /// </summary>
+        /// <param name="type">Address Type. Can be ShipFrom, ShipTo, PointOfOrderAcceptance, PointOfOrderOrigin, SingleLocation.</param>
+        /// <param name="line1">Street address, attention line, or business name of the location.</param>
+        /// <param name="line2">Street address, business name, or apartment/unit number of the location.</param>
+        /// <param name="line3">Street address or apartment/unit number of the location.</param>
+        /// <param name="city">City of the location.</param>
+        /// <param name="region">State or Region of the location.</param>
+        /// <param name="postalCode">Postal/zip code of the location.</param>
+        /// <param name="country">Two-letter country code of the location.</param>
+        /// <param name="latitude">latitude of the location</param>
+        /// <param name="longitude">longitude of the location</param>
+        /// <returns></returns>
+        public TransactionBuilder WithLineAddress(TransactionAddressType type, string line1, string line2, string line3, string city, string region, string postalCode, string country, decimal latitude, decimal longitude)
+        {
+            var line = GetMostRecentLine("WithLineAddress");
+            if (line.addresses == null) line.addresses = new AddressesModel();
+            var ai = new AddressLocationInfo
+            {
+                line1 = line1,
+                line2 = line2,
+                line3 = line3,
+                city = city,
+                region = region,
+                postalCode = postalCode,
+                country = country,
+                latitude = latitude,
+                longitude = longitude
+            };
+            SetAddress(line.addresses, type, ai);
+            return this;
+        }
+
         /// <summary>
         /// Add an address to this line using an existing company location code.
         /// 


### PR DESCRIPTION
The AvaTax REST DotNet DLL arbitrarily prevents setting the latitude/longitude on full addresses using the TransactionBuilder. I have added the following function to allow for this as it's a valid use case. The RESTful API has no problem with it and the Geo location overrides the address, as expected. 

The test results for this change were compared with how the older Avalara.AvaTax.Adapter.dll used to work and the final result is equivalent.

We would like to have the full address plus geo location for reporting purposes.