### PR TITLE
Support timeout being specified in seconds instead of minutes

### DIFF
--- a/src/AvaTaxClient.cs
+++ b/src/AvaTaxClient.cs
@@ -83,7 +83,7 @@ namespace Avalara.AvaTax.RestClient
                 _userConfiguration = userConfiguration;
             }
 #if PORTABLE
-            this.httpClient = new HttpClient() { Timeout = TimeSpan.FromMinutes(_userConfiguration.TimeoutInMinutes) };
+            this.httpClient = new HttpClient() { Timeout = _userConfiguration.GetTimeOutTimeSpan() };
 #endif
 
             // Setup the URI
@@ -118,7 +118,7 @@ namespace Avalara.AvaTax.RestClient
                 _userConfiguration = userConfiguration;
             }
 #if PORTABLE
-            this.httpClient = new HttpClient() { Timeout = TimeSpan.FromMinutes(_userConfiguration.TimeoutInMinutes) };
+            this.httpClient = new HttpClient() { Timeout = _userConfiguration.GetTimeOutTimeSpan() };
 #endif
             _envUri = customEnvironment;
         }
@@ -145,7 +145,7 @@ namespace Avalara.AvaTax.RestClient
             }
 
             this.httpClient = httpClient ?? new HttpClient()
-                { Timeout = TimeSpan.FromMinutes(_userConfiguration.TimeoutInMinutes) };
+                { Timeout = _userConfiguration.GetTimeOutTimeSpan() };
 
             // Setup the URI
             switch (environment)
@@ -181,7 +181,7 @@ namespace Avalara.AvaTax.RestClient
             }
 
             this.httpClient = httpClient ?? new HttpClient()
-                { Timeout = TimeSpan.FromMinutes(_userConfiguration.TimeoutInMinutes) };
+                { Timeout = _userConfiguration.GetTimeOutTimeSpan() };
 
             _envUri = customEnvironment;
         }

--- a/src/UserConfiguration.cs
+++ b/src/UserConfiguration.cs
@@ -6,6 +6,7 @@ namespace Avalara.AvaTax.RestClient
     public class UserConfiguration
     {
         private int _timeOutInMinutes;
+        private int _timeOutInSeconds;
         private int _maxRetryAttempts;
 
         /// <summary>
@@ -18,6 +19,26 @@ namespace Avalara.AvaTax.RestClient
             {
                 _timeOutInMinutes = value <= 0 ? 20 : value;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets timeout in seconds. If set to a non-zero value, overrides TimeoutInMinutes.
+        /// </summary>
+        public int TimeoutInSeconds
+        {
+            get { return _timeOutInSeconds; }
+            set
+            {
+                _timeOutInSeconds = value <= 0 ? 0 : value;
+            }
+        }
+
+        /// <summary>
+        /// Get <see cref="TimeSpan"/> for the currently set timeout period.
+        /// </summary>
+        public TimeSpan GetTimeOutTimeSpan()
+        {
+            return _timeOutInSeconds > 0 ? TimeSpan.FromSeconds(_timeOutInSeconds) : TimeSpan.FromMinutes(_timeOutInMinutes);
         }
 
         /// <summary>
@@ -39,6 +60,7 @@ namespace Avalara.AvaTax.RestClient
         {
             this._maxRetryAttempts = 0;
             this._timeOutInMinutes = 20;
+            this._timeOutInSeconds = 0;
         }
     }
 }


### PR DESCRIPTION
Minutes are not sufficiently granular for a timeout period.  Added capability for timeout to be specified in seconds (considered milliseconds, but that's excessively granular for this type of service).  Maintains backwards compatibility.  Seconds value will override minutes if set.