### PR TITLE
Added Default TextCase option

### DIFF
--- a/src/enums/TextCase.cs
+++ b/src/enums/TextCase.cs
@@ -21,14 +21,18 @@ namespace Avalara.AvaTax.RestClient
     public enum TextCase
     {
         /// <summary>
+        /// Default (casing determined by address standardization setting in Avalara)
+        /// </summary>
+        Default = 0,
+        
+        /// <summary>
         /// Upper case
         /// </summary>
-        Upper = 0,
+        Upper = 1,
 
         /// <summary>
         /// Mixed Case
         /// </summary>
-        Mixed = 1,
-
+        Mixed = 2,
     }
 }


### PR DESCRIPTION
Added Default TextCase.  Verified with PostMan this is still supported and has a literal value of 0 in the web service, also confirmed by Avalara employee Kajal Choudhari [on your developer forum](https://developercommunity.avalara.com/s/question/0D5Uz00000nNyUVKA0/why-was-default-use-avalara-setting-textcase-option-removed-for-address-validation-requests). 