### PR TITLE
Add response correlation IDs to AvaTax errors.

### DIFF
--- a/src/AvaTaxClient.cs
+++ b/src/AvaTaxClient.cs
@@ -523,11 +523,11 @@ namespace Avalara.AvaTax.RestClient
                             if (result.StatusCode == HttpStatusCode.InternalServerError ||
                                 result.StatusCode == HttpStatusCode.RequestTimeout)
                             {
-                                throw new AvaTaxServerError(err, result.StatusCode);
+                                throw new AvaTaxServerError(err, result.StatusCode, xCorrelationId);
                             }
                             else
                             {
-                                throw new AvaTaxError(err, result.StatusCode);
+                                throw new AvaTaxError(err, result.StatusCode, xCorrelationId);
                             }
                         }
                     }
@@ -690,11 +690,11 @@ namespace Avalara.AvaTax.RestClient
                     if (result.StatusCode == HttpStatusCode.InternalServerError ||
                         result.StatusCode == HttpStatusCode.RequestTimeout)
                     {
-                        throw new AvaTaxServerError(err, result.StatusCode);
+                        throw new AvaTaxServerError(err, result.StatusCode, xCorrelationId);
                     }
                     else
                     {
-                        throw new AvaTaxError(err, result.StatusCode);
+                        throw new AvaTaxError(err, result.StatusCode, xCorrelationId);
                     }
                 }
             }
@@ -894,7 +894,7 @@ namespace Avalara.AvaTax.RestClient
 
                             // Pass on the error
 
-                            throw new AvaTaxError(err, httpWebResponse.StatusCode);
+                            throw new AvaTaxError(err, httpWebResponse.StatusCode, httpWebResponse.Headers.Get(HEADER_X_CORRELATION_ID));
                         }
                     }
                 }
@@ -1033,7 +1033,7 @@ namespace Avalara.AvaTax.RestClient
                             OnCallCompleted(eventargs);
 
                             // Here's the results
-                            throw new AvaTaxError(err, httpWebResponse.StatusCode);
+                            throw new AvaTaxError(err, httpWebResponse.StatusCode, httpWebResponse.Headers.Get(HEADER_X_CORRELATION_ID));
                         }
                     }
                 }

--- a/src/AvaTaxError.cs
+++ b/src/AvaTaxError.cs
@@ -19,14 +19,31 @@ namespace Avalara.AvaTax.RestClient
         public ErrorResult error { get; set; }
 
         /// <summary>
+        /// The response correlation ID returned by AvaTax
+        /// </summary>
+        public string XCorrelationId { get; set; }
+
+        /// <summary>
         /// Constructs an error object for an API call
         /// </summary>
         /// <param name="err"></param>
         /// <param name="code"></param>
         public AvaTaxError(ErrorResult err, HttpStatusCode code)
+            : this(err, code, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs an error object for an API call
+        /// </summary>
+        /// <param name="err"></param>
+        /// <param name="code"></param>
+        /// <param name="xCorrelationId"></param>
+        public AvaTaxError(ErrorResult err, HttpStatusCode code, string xCorrelationId)
         {
             this.error = err;
             this.statusCode = code;
+            this.XCorrelationId = xCorrelationId;
         }
     }
 }

--- a/src/AvaTaxServerError.cs
+++ b/src/AvaTaxServerError.cs
@@ -13,7 +13,18 @@ namespace Avalara.AvaTax.RestClient
         /// <param name="errorResult">Error Result</param>
         /// <param name="statusCode">HTTP status code</param>
         public AvaTaxServerError(ErrorResult errorResult, HttpStatusCode statusCode)
-            : base(errorResult, statusCode)
+            : this(errorResult, statusCode, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes <see cref="AvaTaxServerError"/> class
+        /// </summary>
+        /// <param name="errorResult">Error Result</param>
+        /// <param name="statusCode">HTTP status code</param>
+        /// <param name="xCorrelationId">Response correlation ID</param>
+        public AvaTaxServerError(ErrorResult errorResult, HttpStatusCode statusCode, string xCorrelationId)
+            : base(errorResult, statusCode, xCorrelationId)
         {
         }
     }

--- a/tests/netstandard/ErrorResultTests.cs
+++ b/tests/netstandard/ErrorResultTests.cs
@@ -40,6 +40,8 @@ namespace Avalara.AvaTax.RestClient.Test.netstandard
         public async Task JsonErrorResult()
         {
             AvaTaxError avataxError = null;
+            AvaTaxCallEventArgs callCompletedEvent = null;
+            _client.CallCompleted += (sender, e) => callCompletedEvent = e as AvaTaxCallEventArgs;
             try
             {
                 var result = await _client.ChangePasswordAsync(new PasswordChangeModel
@@ -52,10 +54,13 @@ namespace Avalara.AvaTax.RestClient.Test.netstandard
             }
 
             Assert.NotNull(avataxError);
+            Assert.NotNull(callCompletedEvent);
             var details = avataxError.error.error.details[0];
             var code = avataxError.error.error.code;
             Assert.True(details.description.Contains("oldPassword"));
             Assert.True(code == ErrorCodeId.ValueRequiredError);
+            Assert.False(string.IsNullOrWhiteSpace(callCompletedEvent.XCorrelationId));
+            Assert.AreEqual(callCompletedEvent.XCorrelationId, avataxError.XCorrelationId);
         }
     }
 }

--- a/tests/netstandard20/ErrorResultTests.cs
+++ b/tests/netstandard20/ErrorResultTests.cs
@@ -39,6 +39,8 @@ namespace Avalara.AvaTax.RestClient.Test.netstandard20
         public async Task JsonErrorResult()
         {
             AvaTaxError avataxError = null;
+            AvaTaxCallEventArgs callCompletedEvent = null;
+            _client.CallCompleted += (sender, e) => callCompletedEvent = e as AvaTaxCallEventArgs;
             try
             {
                 var result = await _client.ChangePasswordAsync(new PasswordChangeModel
@@ -51,10 +53,13 @@ namespace Avalara.AvaTax.RestClient.Test.netstandard20
             }
 
             Assert.NotNull(avataxError);
+            Assert.NotNull(callCompletedEvent);
             var details = avataxError.error.error.details[0];
             var code = avataxError.error.error.code;
             Assert.True(details.description.Contains("oldPassword"));
             Assert.True(code == ErrorCodeId.ValueRequiredError);
+            Assert.False(string.IsNullOrWhiteSpace(callCompletedEvent.XCorrelationId));
+            Assert.AreEqual(callCompletedEvent.XCorrelationId, avataxError.XCorrelationId);
         }
     }
 }


### PR DESCRIPTION
## Summary
- surface the AvaTax response `x-correlation-id` on thrown `AvaTaxError` and `AvaTaxServerError` instances
- pass the correlation ID through all existing error throw paths
- add test coverage to verify the exception carries the same correlation ID exposed by `CallCompleted`

## Test plan
- [x] verified in downstream QA usage that correlation IDs now appear on SDK-thrown errors
- [x] ran `dotnet test "tests/Avalara.AvaTax.RestClient.Test.csproj" --framework netcoreapp3.1 --filter "FullyQualifiedName~ErrorResultTests.JsonErrorResult"`
- [x] ran `dotnet build "tests/Avalara.AvaTax.RestClient.Test.csproj" --framework netcoreapp2.2`